### PR TITLE
Disable `Style/HashLikeCase` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Added
+- Disable `Style/HashLikeCase` rule
+
 ## v0.2.2 (2020-07-13)
 ### Added
 - Disable `Style/RedundantFileExtensionInRequire` rule

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    runger_style (0.2.2)
+    runger_style (0.2.3.alpha)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/runger_style/version.rb
+++ b/lib/runger_style/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RungerStyle
-  VERSION = '0.2.2'
+  VERSION = '0.2.3.alpha'
 end

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -80,6 +80,8 @@ Style/GlobalVars:
   Enabled: false
 Style/GuardClause:
   Enabled: false
+Style/HashLikeCase:
+  Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
 Style/ImplicitRuntimeError:


### PR DESCRIPTION
As discussed here https://github.com/rubocop-hq/rubocop/issues/ 8247 , there is not much (/almost any) of a performance benefit, and I don't think that the enforced style is a whole lot (if any) better than using a `case` statement.