### PR TITLE
Disable `Rails/OrderById`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Added
+- Disable `Rails/OrderById` in `rulesets/rails.yml`
+
 ## v0.2.6 (2021-01-01)
 ### Added
 - Don't require parens for `timestamps` method calls

--- a/lib/runger_style/version.rb
+++ b/lib/runger_style/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RungerStyle
-  VERSION = '0.2.6'
+  VERSION = '0.2.7.alpha'
 end

--- a/rulesets/rails.yml
+++ b/rulesets/rails.yml
@@ -10,6 +10,8 @@ Rails/BulkChangeTable:
 Rails/CreateTableWithTimestamps:
   Exclude:
     - !ruby/regexp /db/migrate/201[1-9].*\.rb\z/
+Rails/OrderById:
+  Enabled: false
 Rails/Output:
   Enabled: false
 Rails/NotNullColumn:


### PR DESCRIPTION
It's somewhat common (especially in specs, but also in application code) to have a legitimate reason to order by `id`.