### PR TITLE
Don't require parens for `and` method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Added
+- Don't require parens for `and` method calls (e.g. in RSpec compound expectations)
+
 ## v0.2.12 (2021-01-08)
 ### Added
 - Don't require parens for `boolean` method calls

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    runger_style (0.2.12)
+    runger_style (0.2.13.alpha)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/runger_style/version.rb
+++ b/lib/runger_style/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RungerStyle
-  VERSION = '0.2.12'
+  VERSION = '0.2.13.alpha'
 end

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -110,6 +110,7 @@ Style/MethodCallWithArgsParentheses:
     - add_foreign_key
     - add_index
     - add_reference
+    - and
     - belongs_to
     - bigint
     - boolean


### PR DESCRIPTION
(e.g. in RSpec compound expectations)