### PR TITLE
Disable two cops

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/davidrunger/release_assistant.git
-  revision: 77c50a611b6ecb91ac78092a8eae4943046ad3fe
+  revision: 830b1a7675310ac320978ef702b3515b7607b8a7
   specs:
     release_assistant (0.3.3.alpha)
       activesupport (~> 6.0)
@@ -36,7 +36,7 @@ GEM
     rake (13.0.3)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.17.0)
+    rubocop (1.18.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -69,6 +69,8 @@ Metrics/ClassLength:
   Enabled: false
 Metrics/MethodLength:
   Max: 30
+Naming/InclusiveLanguage:
+  Enabled: false
 Naming/RescuedExceptionsVariableName:
   Enabled: false
 Naming/VariableNumber:

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -33,6 +33,9 @@ Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 Layout/FirstMethodArgumentLineBreak:
   Enabled: false
+Layout/LineEndStringConcatenationIndentation:
+  Exclude:
+    - bin/*
 Layout/LineLength:
   IgnoredPatterns:
     # ignore line length if the line is a comment without any spaces; it's probably not something we


### PR DESCRIPTION
This disables `Naming/InclusiveLanguage` everywhere and `Layout/LineEndStringConcatenationIndentation` in `bin/*` files.