### PR TITLE
Disable Layout/RedundantLineBreak cop

### DIFF
--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -44,6 +44,8 @@ Layout/LineLength:
   Max: 100
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
+Layout/RedundantLineBreak:
+  Enabled: false
 Layout/SingleLineBlockChain:
   Enabled: false
 Layout/SpaceBeforeBlockBraces:


### PR DESCRIPTION
I'm sort of sad to do this, because I do like when RuboCop tells me that I can condense some code onto a single line, but sometimes I want to break onto multiple lines for clarity even if I could fit everything on a single line.