### PR TITLE
Disable `Style/GlobalStdStream` cop

### DIFF
--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -101,6 +101,8 @@ Style/EmptyCaseCondition:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: true
+Style/GlobalStdStream:
+  Enabled: false
 Style/GlobalVars:
   Enabled: false
 Style/GuardClause:


### PR DESCRIPTION
The rationale for this cop (https://docs.rubocop.org/rubocop/cops_style.html#styleglobalstdstream) doesn't really make sense to me. It seems like an argument for enforcing the opposite of what this cop actually does.