### PR TITLE
Add rubocop as an explicit runtime dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/davidrunger/release_assistant.git
-  revision: e738d93b7d66c41b6269750127e55db7a3c06b77
+  revision: eb13b811c325b1d5784a204ebe4b7e06f5a756ac
   specs:
     release_assistant (0.3.3.alpha)
       activesupport (>= 6, < 8)
@@ -12,6 +12,7 @@ PATH
   remote: .
   specs:
     runger_style (0.2.22.alpha)
+      rubocop (>= 1.38.0, < 2)
 
 GEM
   remote: https://rubygems.org/

--- a/runger_style.gemspec
+++ b/runger_style.gemspec
@@ -27,4 +27,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 3.1.0'
+
+  spec.add_runtime_dependency('rubocop', '>= 1.38.0', '< 2')
 end


### PR DESCRIPTION
This gem does require rubocop; we should be upfront about that.