### PR TITLE
Exclude spec_helper.rb from Style/RequireOrder cop

### DIFF
--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -188,6 +188,7 @@ Style/RegexpLiteral:
 Style/RequireOrder:
   Exclude:
     - bin/*
+    - spec/spec_helper.rb
 Style/RescueModifier:
   Enabled: false
 Style/RescueStandardError:


### PR DESCRIPTION
I think that often the require order in spec_helper.rb cannot be alphabetized because one or more of the dependencies must be required after one or more specific other dependencies.