### PR TITLE
Add all rubocop-* dependencies in test and include in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
 inherit_from:
+  - rulesets/capybara.yml
   - rulesets/default.yml
   - rulesets/performance.yml
+  - rulesets/rails.yml
+  - rulesets/rake.yml
+  - rulesets/rspec.yml

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,10 @@ end
 group :development do
   gem 'release_assistant', require: false, github: 'davidrunger/release_assistant'
 end
+
+group :test do
+  gem 'rubocop-capybara'
+  gem 'rubocop-rails'
+  gem 'rubocop-rake'
+  gem 'rubocop-rspec'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
     parallel (1.23.0)
     parser (3.2.2.0)
       ast (~> 2.4.1)
+    rack (2.2.7)
     rainbow (3.1.1)
     rake (13.0.6)
     regexp_parser (2.8.0)
@@ -49,9 +50,20 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.28.0)
       parser (>= 3.2.1.0)
+    rubocop-capybara (2.18.0)
+      rubocop (~> 1.41)
     rubocop-performance (1.17.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.19.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.33.0, < 2.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.20.0)
+      rubocop (~> 1.33)
+      rubocop-capybara (~> 2.17)
     ruby-progressbar (1.13.0)
     slop (4.10.1)
     tzinfo (2.0.6)
@@ -66,7 +78,11 @@ DEPENDENCIES
   rake
   release_assistant!
   rubocop
+  rubocop-capybara
   rubocop-performance
+  rubocop-rails
+  rubocop-rake
+  rubocop-rspec
   runger_style!
 
 BUNDLED WITH


### PR DESCRIPTION
Although we don't use all of them, this will allow us to test our configurations for these gems by running rubocop in this repo.