### PR TITLE
Bump bundler from 2.2.22 to 2.4.13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,4 +84,4 @@ DEPENDENCIES
   runger_style!
 
 BUNDLED WITH
-   2.2.22
+   2.4.13


### PR DESCRIPTION
This gets rid of this warning when running gem executables: https://github.com/rubygems/rubygems/issues/ 5234 .