### PR TITLE
Disable Style/ArgumentsForwarding and Naming/BlockForwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-[no unreleased changes yet]
+- Disable `Style/ArgumentsForwarding`
+- Disable `Naming/BlockForwarding`
 
 ## v1.1.0 (2023-12-29)
 ### Changed

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -75,11 +75,15 @@ Metrics/MethodLength:
   Max: 30
 Metrics/ModuleLength:
   Enabled: false
+Naming/BlockForwarding:
+  Enabled: false
 Naming/InclusiveLanguage:
   Enabled: false
 Naming/RescuedExceptionsVariableName:
   Enabled: false
 Naming/VariableNumber:
+  Enabled: false
+Style/ArgumentsForwarding:
   Enabled: false
 Style/ArrayFirstLast:
   Enabled: false


### PR DESCRIPTION
These seem not to be compatible with Ruby 3.3.0.