### PR TITLE
Limit ForbiddenPrefixes for Naming/PredicateName to "is_"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Limit ForbiddenPrefixes for Naming/PredicateName to "is_"
 
 ## v2.1.0 (2024-03-15)
 - Remove global exclusions and lint db/schema.rb except for some cops

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -79,6 +79,9 @@ Naming/BlockForwarding:
   Enabled: false
 Naming/InclusiveLanguage:
   Enabled: false
+Naming/PredicateName:
+  ForbiddenPrefixes:
+    - is_
 Naming/RescuedExceptionsVariableName:
   Enabled: false
 Naming/VariableNumber:


### PR DESCRIPTION
I think it's fine for predicate methods to start with `has_` or `have_`. A predicate method named `null_byte?` means "is this a null byte?". "Does this have a null byte?" is a separate question, which should be answered by a method named `has_null_byte?`.