### PR TITLE
Reenable Layout/HeredocIndentation cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Reenable `Layout/HeredocIndentation` cop
 
 ## v2.4.0 (2024-05-23)
 - Set `ActiveSupportExtensionsEnabled` to true in `rails.yml`

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -35,8 +35,6 @@ Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 Layout/FirstMethodArgumentLineBreak:
   Enabled: false
-Layout/HeredocIndentation:
-  Enabled: false # disabled (hopefully temporarily) due to prism/rubocop bug with this cop
 Layout/LineEndStringConcatenationIndentation:
   Exclude:
     - bin/*


### PR DESCRIPTION
The relevant bug was fixed in prism 0.30.0 (as mentioned here https://github.com/rubocop/rubocop/issues/ 12869#issuecomment-2158284082).