### PR TITLE
Move RSpecRails cop to separate YAML file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Move RSpecRails cop to separate YAML file
 
 ## v2.5.0 (2024-06-10)
 - Reenable `Layout/HeredocIndentation` cop

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ inherit_gem:
     - rulesets/performance.yml # gem 'rubocop-performance'
     - rulesets/rails.yml # gem 'rubocop-rails'
     - rulesets/rake.yml # gem 'rubocop-rake'
+    - rulesets/rspec_rails.yml # gem 'rubocop-rspec_rails'
     - rulesets/rspec.yml # gem 'rubocop-rspec'
 ```
 

--- a/rulesets/rspec.yml
+++ b/rulesets/rspec.yml
@@ -39,5 +39,3 @@ RSpec/MessageSpies:
   Enabled: false
 RSpec/NestedGroups:
   Enabled: false
-RSpecRails/HttpStatus:
-  Enabled: false

--- a/rulesets/rspec_rails.yml
+++ b/rulesets/rspec_rails.yml
@@ -1,0 +1,5 @@
+require:
+  - rubocop-rspec_rails
+
+RSpecRails/HttpStatus:
+  Enabled: false


### PR DESCRIPTION
This is (basically) a required change since the release of `rubocop-rspec` 3.0.0, which separates out `rubocop-rspec_rails` into a separate gem (along with `rubocop-capybara` and `rubocop-factory_bot`, which we already have separate YAML files for).