### PR TITLE
Change references to "master" branch to "main"

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,7 +3,7 @@ name: Run Rubocop
 on:
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Rename primary branch from `master` to `main`
 
 ## v2.6.0 (2024-06-12)
 - Move RSpecRails cop to separate YAML file

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-1. check out the `master` branch
+1. check out the `main` branch
 2. update `CHANGELOG.md`
 3. update the version number in `version.rb`
 4. `bundle install` (which will update `Gemfile.lock`)

--- a/runger_style.gemspec
+++ b/runger_style.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/davidrunger/runger_style'
   spec.metadata['changelog_uri'] =
-    'https://github.com/davidrunger/runger_style/blob/master/CHANGELOG.md'
+    'https://github.com/davidrunger/runger_style/blob/main/CHANGELOG.md'
 
   spec.files =
     `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
I have renamed the "master" branch in GitHub to "main", so we need to update these references to reflect that change.