### PR TITLE
[default] Enable Layout/FirstMethodArgumentLineBreak [STYL-1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Enable `Layout/FirstMethodArgumentLineBreak`
 
 ## v2.9.0 (2024-06-28)
 - Enforce only major and minor parts of required Ruby version (loosening the required Ruby version from 3.3.3 to 3.3.0)

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -33,8 +33,6 @@ Layout/FirstArgumentIndentation:
   Enabled: false # this rule doesn't play nicely with the way that I like to use `memoize`
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
-Layout/FirstMethodArgumentLineBreak:
-  Enabled: false
 Layout/LineEndStringConcatenationIndentation:
   Exclude:
     - bin/*


### PR DESCRIPTION
I'm not too sure why I disabled this in #30 / 062d71b7 . It seems like a good rule, particularly because it makes autocorrection more helpful when trying to split a method call onto multiple lines. Let's enable it now (by deleting the rule that disables it).