### PR TITLE
Disable Style/FormatString cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Disable `Style/FormatString` cop
 
 ## v2.11.0 (2024-07-05)
 - Set `AllowMultilineFinalElement: true` for `Layout/FirstMethodArgumentLineBreak`

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -117,6 +117,8 @@ Style/DocumentationMethod:
   Enabled: false
 Style/EmptyCaseCondition:
   Enabled: false
+Style/FormatString:
+  Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: true
 Style/GlobalStdStream:


### PR DESCRIPTION
The reason given for this rule in the style guide ( https://rubystyle.guide/#sprintf ) is that the `String#%` method is "fairly cryptic", which I suppose is true, but I think it's a method worth becoming familiar with, and, once one does that, then I think it's pleasantly concise and no longer very cryptic.