### PR TITLE
Ignore Layout/LineLength for RSpec example descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Ignore `Layout/LineLength` for RSpec example descriptions
 
 ## v2.12.0 (2024-07-11)
 - Disable `Style/FormatString` cop

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -40,9 +40,11 @@ Layout/LineEndStringConcatenationIndentation:
     - bin/*
 Layout/LineLength:
   AllowedPatterns:
-    # ignore line length if the line is a comment without any spaces; it's probably not something we
-    # can fix (e.g. a long file path)
+    # Ignore line length if the line is a comment without any spaces; it's probably not something we
+    # can fix (e.g. a long file path):
     - !ruby/regexp /^ *#? [\S]+$/
+    # Ignore RSpec example descriptions:
+    - !ruby/regexp /^ *it ['"].*['"].*do$/
   Max: 100
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented


### PR DESCRIPTION
Sometimes, including more detail in an example description is more important than keeping the line short, and better than splitting the example description onto multiple lines.