### PR TITLE
[gemspec] Remove upper bounds on versions for all dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Remove upper bounds on versions for all dependencies.
 
 ## v2.17.0 (2024-09-03)
 - Ignore long annotate comments about indexes (re: `Layout/LineLength`)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     runger_style (2.17.1.alpha)
       prism (>= 0.24.0)
-      rubocop (>= 1.38.0, < 2)
+      rubocop (>= 1.38.0)
 
 GEM
   remote: https://rubygems.org/

--- a/runger_style.gemspec
+++ b/runger_style.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= #{required_ruby_version}"
 
   spec.add_dependency('prism', '>= 0.24.0')
-  spec.add_dependency('rubocop', '>= 1.38.0', '< 2')
+  spec.add_dependency('rubocop', '>= 1.38.0')
 end


### PR DESCRIPTION
Let's optimistically assume that all future versions will be compatible. We can add restrictions or roll out a fix if that turns out not to be the case.

The upside of this change is that we don't have to make changes to this gem's gemspec to accommodate newly released versions of its dependencies.