### PR TITLE
Increase minimum required 'rubocop' version to 1.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Increase minimum required `rubocop` version to 1.68.0.
 
 ## v2.19.0 (2024-12-10)
 - Disable `Style/SafeNavigationChainLength` cop.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     runger_style (2.19.1.alpha)
       prism (>= 0.24.0)
-      rubocop (>= 1.38.0)
+      rubocop (>= 1.68.0)
 
 GEM
   remote: https://rubygems.org/

--- a/runger_style.gemspec
+++ b/runger_style.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= #{required_ruby_version}"
 
   spec.add_dependency('prism', '>= 0.24.0')
-  spec.add_dependency('rubocop', '>= 1.38.0')
+  spec.add_dependency('rubocop', '>= 1.68.0')
 end


### PR DESCRIPTION
In that `rubocop` version (1.68.0), the `Style/SafeNavigationChainLength` cop was added. Since we disable that cop, an error occurs if that cop is not present in the current RuboCop version. Thus, we must have at least RuboCop version 1.68.0, and so this change adds it as a requirement in the gemspec.