### PR TITLE
Enable 'Style/BlockDelimiters' (except for 'expect' method)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Enable `Style/BlockDelimiters` (except for `expect` method)
 
 ## v4.0.1 (2024-12-31)
 - Increase TargetRubyVersion from 3.3 to 3.4

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -102,7 +102,9 @@ Style/ArgumentsForwarding:
 Style/ArrayFirstLast:
   Enabled: false
 Style/BlockDelimiters:
-  Enabled: false
+  Enabled: true
+  AllowedMethods:
+    - expect
 Style/ClassAndModuleChildren:
   EnforcedStyle: compact
 Style/ClassMethodsDefinitions:


### PR DESCRIPTION
In specs, I want to be able to write things like this:

```rb
expect {
  run
}.to change {
  quiz.questions.count
}.by(2)
```

which is why I am adding `expect` to the `AllowedMethods` option.