### PR TITLE
Explicitly declare 'module RungerStyle'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Explicitly declare `module RungerStyle` in `RungerStyle/MultilineMethodArgumentsLineBreaks` definition.
 
 ## v4.2.0 (2025-01-27)
 - Add `RungerStyle/MultilineMethodArgumentsLineBreaks` cop.

--- a/lib/runger_style/cops/multiline_method_arguments_line_breaks.rb
+++ b/lib/runger_style/cops/multiline_method_arguments_line_breaks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module RungerStyle
+module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
   class MultilineMethodArgumentsLineBreaks < ::RuboCop::Cop::Base
     extend RuboCop::Cop::AutoCorrector
     include RuboCop::Cop::RangeHelp

--- a/lib/runger_style/cops/multiline_method_arguments_line_breaks.rb
+++ b/lib/runger_style/cops/multiline_method_arguments_line_breaks.rb
@@ -1,41 +1,43 @@
 # frozen_string_literal: true
 
-class RungerStyle::MultilineMethodArgumentsLineBreaks < RuboCop::Cop::Base
-  extend RuboCop::Cop::AutoCorrector
-  include RuboCop::Cop::RangeHelp
+module RungerStyle
+  class MultilineMethodArgumentsLineBreaks < ::RuboCop::Cop::Base
+    extend RuboCop::Cop::AutoCorrector
+    include RuboCop::Cop::RangeHelp
 
-  MSG = 'Each argument in a multi-line method call must start on a separate line.'
+    MSG = 'Each argument in a multi-line method call must start on a separate line.'
 
-  def on_send(node)
-    return unless node.multiline?
-    return if node.arguments.size <= 1
+    def on_send(node)
+      return unless node.multiline?
+      return if node.arguments.size <= 1
 
-    node.arguments.each_cons(2) do |arg1, arg2|
-      next unless same_line?(arg1, arg2)
+      node.arguments.each_cons(2) do |arg1, arg2|
+        next unless same_line?(arg1, arg2)
 
-      separator = separator_range(arg1, arg2)
+        separator = separator_range(arg1, arg2)
 
-      add_offense(separator, message: MSG) do |corrector|
-        base_indent = base_indentation(arg1)
-        replacement = ",\n#{base_indent}"
-        corrector.replace(separator, replacement)
+        add_offense(separator, message: MSG) do |corrector|
+          base_indent = base_indentation(arg1)
+          replacement = ",\n#{base_indent}"
+          corrector.replace(separator, replacement)
+        end
       end
     end
-  end
 
-  private
+    private
 
-  def same_line?(arg1, arg2)
-    arg1.source_range.last_line == arg2.source_range.first_line
-  end
+    def same_line?(arg1, arg2)
+      arg1.source_range.last_line == arg2.source_range.first_line
+    end
 
-  def base_indentation(arg)
-    arg.source_range.source_line[/^\s*/]
-  end
+    def base_indentation(arg)
+      arg.source_range.source_line[/^\s*/]
+    end
 
-  def separator_range(arg1, arg2)
-    end_pos = arg1.source_range.end.end_pos
-    begin_pos = arg2.source_range.begin.begin_pos
-    range_between(end_pos, begin_pos)
+    def separator_range(arg1, arg2)
+      end_pos = arg1.source_range.end.end_pos
+      begin_pos = arg2.source_range.begin.begin_pos
+      range_between(end_pos, begin_pos)
+    end
   end
 end


### PR DESCRIPTION
I am seeing an error ([example][1]) about "uninitialized constant RungerStyle" in projects trying to upgrade to 4.2.0. Unfortunately, this error seems to only occur for the RubyGems-installed version of the package; when I test locally with `path: '/home/david/code/runger_style'`, the error does not occur, because then the gemspec is evaluated, and the gemspec loads the version file, which declares the `RungerStyle` module.

I think that this change will fix the issue by explicitly declaring a `RungerStyle` module in the `RungerStyle/MultilineMethodArgumentsLineBreaks` cop definition.

[1]: https://github.com/davidrunger/david_runger/actions/runs/12995143574/job/36241181210?pr=5941