### PR TITLE
Fix MultilineMethodArgumentsLineBreaks false negative [STYL-3]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-[no unreleased changes yet]
+- Fix false negative for `RungerStyle/MultilineMethodArgumentsLineBreaks` with keyword arguments.
+- Disable `Style/Next`.
 
 ## v4.3.0 (2025-01-31)
 - Specify `EnforcedShorthandSyntax: always` for `Style/HashSyntax`.

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -218,6 +218,8 @@ Style/MultilineMethodSignature:
   Enabled: false
 Style/NegatedIf:
   Enabled: false
+Style/Next:
+  Enabled: false
 Style/NumericPredicate:
   Enabled: false
 Style/ParenthesesAroundCondition:

--- a/spec/runger_style/multiline_method_arguments_line_breaks_spec.rb
+++ b/spec/runger_style/multiline_method_arguments_line_breaks_spec.rb
@@ -8,184 +8,222 @@ RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks do
 
   subject(:cop) { described_class.new }
 
-  context 'when the method call is on a single line' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        foo(a, b, c)
-      RUBY
+  ruby_version =
+    YAML.load_file(
+      'rulesets/default.yml',
+      permitted_classes: [Regexp],
+    ).dig('AllCops', 'TargetRubyVersion')
+
+  context "when the Ruby version is #{ruby_version}" do
+    let(:ruby_version) { ruby_version }
+
+    context 'when the method call is on a single line' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          foo(a, b, c)
+        RUBY
+      end
     end
-  end
 
-  context 'when the method call is multi-line with two arguments on the same line' do
-    it 'registers an offense and autocorrects it' do
-      expect_offense(<<~RUBY)
-        foo(
-          a, b,
-           ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
-        )
-      RUBY
+    context 'when the method call is multi-line with two arguments on the same line' do
+      it 'registers an offense and autocorrects it' do
+        expect_offense(<<~RUBY)
+          foo(
+            a, b,
+             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+          )
+        RUBY
 
-      expect_correction(<<~RUBY)
-        foo(
-          a,
-          b,
-        )
-      RUBY
+        expect_correction(<<~RUBY)
+          foo(
+            a,
+            b,
+          )
+        RUBY
+      end
     end
-  end
 
-  context 'when the method call is multi-line with three arguments on the same line' do
-    it 'registers an offense and autocorrects it' do
-      expect_offense(<<~RUBY)
-        foo(
-          a, b, c,
-           ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+    context 'when the method call is multi-line with two keyword arguments on the same line' do
+      it 'registers an offense and autocorrects it' do
+        expect_offense(<<~RUBY)
+          foo(
+            a:, b: 2,
               ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
-        )
-      RUBY
+          )
+        RUBY
 
-      expect_correction(<<~RUBY)
-        foo(
-          a,
-          b,
-          c,
-        )
-      RUBY
+        expect_correction(<<~RUBY)
+          foo(
+            a:,
+            b: 2,
+          )
+        RUBY
+      end
     end
-  end
 
-  context 'when the method call is multi-line with arguments partially on the same line' do
-    it 'registers an offense and autocorrects it' do
-      expect_offense(<<~RUBY)
-        foo(
-          a, b,
-           ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
-          c,
-        )
-      RUBY
-
-      expect_correction(<<~RUBY)
-        foo(
-          a,
-          b,
-          c,
-        )
-      RUBY
+    context 'when the method call is multi-line with a hash on a single line' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          foo(
+            { a:, b: 2 },
+          )
+        RUBY
+      end
     end
-  end
 
-  context 'when the method call is multi-line and all arguments are already on separate lines' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        foo(
-          a,
-          b,
-          c,
-        )
-      RUBY
+    context 'when the method call is multi-line with three arguments on the same line' do
+      it 'registers an offense and autocorrects it' do
+        expect_offense(<<~RUBY)
+          foo(
+            a, b, c,
+             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+                ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo(
+            a,
+            b,
+            c,
+          )
+        RUBY
+      end
     end
-  end
 
-  context 'when the method call has no arguments' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        foo()
-      RUBY
+    context 'when the method call is multi-line with arguments partially on the same line' do
+      it 'registers an offense and autocorrects it' do
+        expect_offense(<<~RUBY)
+          foo(
+            a, b,
+             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+            c,
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo(
+            a,
+            b,
+            c,
+          )
+        RUBY
+      end
     end
-  end
 
-  context 'when the method call has a single argument' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        foo(
-          a,
-        )
-      RUBY
+    context 'when the method call is multi-line and all arguments are already on separate lines' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          foo(
+            a,
+            b,
+            c,
+          )
+        RUBY
+      end
     end
-  end
 
-  context 'when the method call contains nested method calls as arguments' do
-    it 'registers an offense and autocorrects properly' do
-      expect_offense(<<~RUBY)
-        foo(
-          bar(a, b), c,
-                   ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
-        )
-      RUBY
-
-      expect_correction(<<~RUBY)
-        foo(
-          bar(a, b),
-          c,
-        )
-      RUBY
+    context 'when the method call has no arguments' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          foo()
+        RUBY
+      end
     end
-  end
 
-  context 'when the method call includes trailing comments' do
-    it 'preserves the comments and autocorrects properly' do
-      expect_offense(<<~RUBY)
-        foo(
-          a, b, # trailing comment
-           ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
-        )
-      RUBY
-
-      expect_correction(<<~RUBY)
-        foo(
-          a,
-          b, # trailing comment
-        )
-      RUBY
+    context 'when the method call has a single argument' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          foo(
+            a,
+          )
+        RUBY
+      end
     end
-  end
 
-  context 'when the method call is a chained call' do
-    it 'registers an offense and autocorrects properly' do
-      expect_offense(<<~RUBY)
-        foo.bar(
-          a, b,
-           ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
-        )
-      RUBY
+    context 'when the method call contains nested method calls as arguments' do
+      it 'registers an offense and autocorrects properly' do
+        expect_offense(<<~RUBY)
+          foo(
+            bar(a, b), c,
+                     ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+          )
+        RUBY
 
-      expect_correction(<<~RUBY)
-        foo.bar(
-          a,
-          b,
-        )
-      RUBY
+        expect_correction(<<~RUBY)
+          foo(
+            bar(a, b),
+            c,
+          )
+        RUBY
+      end
     end
-  end
 
-  context 'when the method call includes a block' do
-    it 'registers an offense and autocorrects properly' do
-      expect_offense(<<~RUBY)
-        foo(
-          a, b,
-           ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
-        ) do |x|
-          x.some_method
-        end
-      RUBY
+    context 'when the method call includes trailing comments' do
+      it 'preserves the comments and autocorrects properly' do
+        expect_offense(<<~RUBY)
+          foo(
+            a, b, # trailing comment
+             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+          )
+        RUBY
 
-      expect_correction(<<~RUBY)
-        foo(
-          a,
-          b,
-        ) do |x|
-          x.some_method
-        end
-      RUBY
+        expect_correction(<<~RUBY)
+          foo(
+            a,
+            b, # trailing comment
+          )
+        RUBY
+      end
     end
-  end
 
-  context 'when the method call is part of a multi-line chain and arguments are on a single line' do
-    it 'does not register an offense' do
-      expect_no_offenses(<<~RUBY)
-        foo.
-          bar(a, b)
-      RUBY
+    context 'when the method call is a chained call' do
+      it 'registers an offense and autocorrects properly' do
+        expect_offense(<<~RUBY)
+          foo.bar(
+            a, b,
+             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+          )
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo.bar(
+            a,
+            b,
+          )
+        RUBY
+      end
+    end
+
+    context 'when the method call includes a block' do
+      it 'registers an offense and autocorrects properly' do
+        expect_offense(<<~RUBY)
+          foo(
+            a, b,
+             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+          ) do |x|
+            x.some_method
+          end
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo(
+            a,
+            b,
+          ) do |x|
+            x.some_method
+          end
+        RUBY
+      end
+    end
+
+    context 'when the method call is part of a multi-line chain and arguments are on a single line' do
+      it 'does not register an offense' do
+        expect_no_offenses(<<~RUBY)
+          foo.
+            bar(a, b)
+        RUBY
+      end
     end
   end
 end


### PR DESCRIPTION
Thanks to [DeepSeek][1] and [ChatGPT][2] for their help with this.

[1]: https://chat.deepseek.com/a/chat/s/077929f0-5e6a-4541-befe-fbbee7fa4b7e
[2]: https://chatgpt.com/c/67a86426-5d98-8007-a004-2fbe839cc126

Also, have the spec use the Ruby version specified as `TargetRubyVersion` in `rulesets/default.yml` (currently 3.4), rather than the default (2.7). This is necessary for the keyword argument / hash shorthand syntax to be understood by Ruby.

Also, disable `Style/Next`, because it was interfering with how I want to write the cop.