### PR TITLE
Remove 'RSpec/DescribeClass' custom config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Remove `RSpec/DescribeClass` custom config.
 
 ## v4.4.0 (2025-02-09)
 - Fix false negative for `RungerStyle/MultilineMethodArgumentsLineBreaks` with keyword arguments.

--- a/rulesets/rspec.yml
+++ b/rulesets/rspec.yml
@@ -23,10 +23,6 @@ RSpec/AlignLeftLetBrace:
   Enabled: false
 RSpec/AlignRightLetBrace:
   Enabled: false
-RSpec/DescribeClass:
-  Exclude:
-    # feature specs describe a scenario/flow rather than a single class
-    - spec/features/**/*
 RSpec/DescribedClass:
   Enabled: false
 RSpec/ExpectChange:


### PR DESCRIPTION
https://docs.rubocop.org/rubocop-rspec/cops_rspec.html#rspecdescribeclass

By specifying an `Exclude` option, we were overriding the default `Exclude` options for this cop. But I think that the default is good, and probably better than what we have; it excludes more directories, all of which I think are probably appropriate to exclude (**/spec/features/**/*, **/spec/requests/**/*, **/spec/routing/**/*, **/spec/system/**/*, **/spec/views/**/*).

Therefore, in order to use that larger list of default directories to exclude, this change removes our custom config (which consisted only of an `Exclude` option, which specified only spec/features/**/*).