### PR TITLE
Vastly reduce the number of complaints generated by v4.5.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
-[no unreleased changes yet]
+- **BREAKING:** Rename `MemoizingMethods` config option for `RungerStyle/FirstArgumentIndentation` to `DecoratorMethods`.
+- Add `helper_method` to default `RungerStyle/FirstArgumentIndentation` `DecoratorMethods`.
+- Add `RungerStyle/ArgumentAlignment` cop, which ignores [macro](https://rubydoc.info/github/rubocop/rubocop-ast/RuboCop/AST/MethodDispatchNode#macro%3F-instance_method) methods.
+- Remove `Layout/MultilineAssignmentLayout` custom config that included `send`.
+- Specify `EnforcedStyle: consistent` for `Layout/FirstHashElementIndentation`.
 
 ## v4.5.0 (2025-02-11)
 - Add custom `RungerStyle/MultilineHashValueIndentation` cop.

--- a/lib/runger_style/cops/argument_alignment.rb
+++ b/lib/runger_style/cops/argument_alignment.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
+  class ArgumentAlignment < ::RuboCop::Cop::Layout::ArgumentAlignment
+    def on_send(node)
+      return if node.macro?
+
+      super
+    end
+  end
+end

--- a/lib/runger_style/cops/first_argument_indentation.rb
+++ b/lib/runger_style/cops/first_argument_indentation.rb
@@ -15,7 +15,7 @@ module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
     end
 
     def memoizing_method_names
-      @memoizing_method_names ||= cop_config['MemoizingMethods'].map(&:to_sym)
+      @memoizing_method_names ||= cop_config['DecoratorMethods'].map(&:to_sym)
     end
   end
 end

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -13,6 +13,8 @@ Bundler/GemVersion:
 Layout:
   Exclude:
     - db/schema.rb
+Layout/ArgumentAlignment:
+  Enabled: false # Instead, we use RungerStyle/ArgumentAlignment.
 Layout/BlockAlignment:
   EnforcedStyleAlignWith: start_of_block
 Layout/ClassStructure:
@@ -36,6 +38,8 @@ Layout/FirstArgumentIndentation:
   Enabled: false # Instead, we use RungerStyle/FirstArgumentIndentation.
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
 Layout/FirstMethodArgumentLineBreak:
   AllowMultilineFinalElement: true
 Layout/LineEndStringConcatenationIndentation:
@@ -51,15 +55,6 @@ Layout/LineLength:
     # Ignore RSpec description strings:
     - !ruby/regexp /^ *(context|describe|it) ['"].*['"].* do$/
   Max: 100
-Layout/MultilineAssignmentLayout:
-  SupportedTypes:
-    - block
-    - case
-    - class
-    - if
-    - kwbegin
-    - module
-    - send # This (method calls) is not in the default list.
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 Layout/MultilineOperationIndentation:
@@ -104,13 +99,18 @@ Naming/RescuedExceptionsVariableName:
   Enabled: false
 Naming/VariableNumber:
   Enabled: false
+RungerStyle/ArgumentAlignment:
+  EnforcedStyle: with_first_argument
+  SupportedStyles:
+    - with_first_argument
 RungerStyle/FirstArgumentIndentation:
-  EnforcedStyle: consistent_relative_to_receiver
-  MemoizingMethods:
+  EnforcedStyle: consistent
+  DecoratorMethods:
+    - helper_method
     - memo_wise
     - memoize
   SupportedStyles:
-    - consistent_relative_to_receiver
+    - consistent
 Style:
   Exclude:
     - db/schema.rb

--- a/spec/runger_style/argument_alignment_spec.rb
+++ b/spec/runger_style/argument_alignment_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+
+RSpec.describe RungerStyle::ArgumentAlignment, :config do
+  include RuboCop::RSpec::ExpectOffense
+
+  let(:cop_config) do
+    {
+      'EnforcedStyle' => style,
+      'SupportedStyles' => [style],
+    }
+  end
+
+  context 'when EnforcedStyle is with_first_argument' do
+    let(:style) { 'with_first_argument' }
+
+    context 'when the method being called is a macro' do
+      it 'accepts any indentation of the second argument' do
+        expect_no_offenses(<<~RUBY)
+          get 'some stuff',
+            'and more stuff'
+        RUBY
+      end
+    end
+
+    context 'when the method being called is not a macro' do
+      it 'indents subsequent arguments to align with the first' do
+        expect_offense(<<~RUBY)
+          foo.bar 'some stuff',
+            'and more stuff'
+            ^^^^^^^^^^^^^^^^ Align the arguments of a method call if they span more than one line.
+        RUBY
+
+        expect_correction(<<~RUBY)
+          foo.bar 'some stuff',
+                  'and more stuff'
+        RUBY
+      end
+    end
+  end
+end

--- a/spec/runger_style/first_argument_indentation_spec.rb
+++ b/spec/runger_style/first_argument_indentation_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RungerStyle::FirstArgumentIndentation, :config do
     {
       'EnforcedStyle' => style,
       'SupportedStyles' => [style],
-      'MemoizingMethods' => %w[memoize],
+      'DecoratorMethods' => %w[helper_method memoize],
     }
   end
 
@@ -25,16 +25,17 @@ RSpec.describe RungerStyle::FirstArgumentIndentation, :config do
   context "when the Ruby version is #{ruby_version}" do
     let(:ruby_version) { ruby_version }
 
-    context 'when EnforcedStyle is consistent_relative_to_receiver' do
-      let(:style) { 'consistent_relative_to_receiver' }
+    context 'when EnforcedStyle is consistent' do
+      let(:style) { 'consistent' }
 
       context 'when IndentationWidth:Width is 2' do
         let(:indentation_width) { 2 }
 
-        context 'when memoizing a method listed in MemoizingMethods' do
-          it 'accepts the method definition being aligned with the memoize call' do
+        context 'when "decorating" with method(s) listed in DecoratorMethods' do
+          it 'accepts the method definition being aligned with the "decorator" call' do
             expect_no_offenses(<<~'RUBY')
               class SomeClass
+                helper_method \
                 memoize \
                 def expensive_method
                   do_something_expensive
@@ -44,13 +45,13 @@ RSpec.describe RungerStyle::FirstArgumentIndentation, :config do
           end
         end
 
-        context 'when "decorating" with a method not listed in MemoizingMethods' do
+        context 'when "decorating" with a method not listed in DecoratorMethods' do
           it 'complains about and indents the method definition' do
             expect_offense(<<~'RUBY')
               class SomeClass
                 memo_wise \
                 def expensive_method
-                ^^^^^^^^^^^^^^^^^^^^ Indent the first argument one step more than `memo_wise \`.
+                ^^^^^^^^^^^^^^^^^^^^ Indent the first argument one step more than the start of the previous line.
                   do_something_expensive
                 end
               end


### PR DESCRIPTION
v4.5.0 broke lots of stuff, as e.g. seen [here](https://github.com/davidrunger/david_runger/actions/runs/13276023177/job/37065662485?pr=6103#step:11:144). This change further tweaks various relevant RuboCop configuration so as to get rid of almost all of those new complaints (while still effectuating the changes that were the intent of v4.5.0).