### PR TITLE
Monkeypatch MultilineElementLineBreaks to cover more cases [STYL-4]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Monkeypatch `RuboCop::Cop::MultilineElementLineBreaks` so that arrays will be considered multiline if the array brackets are on separate lines (even if all elements are on a single line).
 
 ## v5.0.1 (2025-02-11)
 - Fix `RungerStyle/MultilineHashValueIndentation` false positive on multiline keys.

--- a/lib/runger_style/cops/require_all_monkeypatches.rb
+++ b/lib/runger_style/cops/require_all_monkeypatches.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Dir[File.expand_path('../monkeypatches/**/*.rb', __dir__)].each do |file|
+  require file
+end

--- a/lib/runger_style/monkeypatches/multiline_element_line_breaks.rb
+++ b/lib/runger_style/monkeypatches/multiline_element_line_breaks.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module RungerStyle::MultilineElementLineBreaksPatches
+  private
+
+  def check_line_breaks(node, children, ignore_last: false)
+    return if single_line?(node, children, ignore_last:)
+
+    last_seen_line = -1
+    children.each do |child|
+      if last_seen_line >= child.first_line
+        add_offense(child) do |corrector|
+          RuboCop::Cop::EmptyLineCorrector.insert_before(corrector, child)
+        end
+      else
+        last_seen_line = child.last_line
+      end
+    end
+  end
+
+  def single_line?(node, children, ignore_last: false)
+    if node.array_type?
+      node.first_line == node.last_line
+    else
+      all_on_same_line?(children, ignore_last:)
+    end
+  end
+end
+
+RuboCop::Cop::MultilineElementLineBreaks.prepend(
+  RungerStyle::MultilineElementLineBreaksPatches,
+)

--- a/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rubocop'
+require 'rubocop/rspec/support'
+
+RSpec.describe RuboCop::Cop::Layout::MultilineArrayLineBreaks, :config do
+  include RuboCop::RSpec::ExpectOffense
+
+  context 'when on same line' do
+    it 'does not add any offenses' do
+      expect_no_offenses(<<~RUBY)
+        [1,2,3]
+      RUBY
+    end
+  end
+
+  context 'when on same line, separate line from brackets' do
+    # NOTE: This spec is modified/inverted from the original RuboCop spec.
+    # All other specs in this file are substantively unmodified.
+    it 'registers an offense and autocorrects it' do
+      expect_offense(<<~RUBY)
+        [
+          1, 2, 3,
+                ^ Each item in a multi-line array must start on a separate line.
+             ^ Each item in a multi-line array must start on a separate line.
+        ]
+      RUBY
+
+      # NOTE: This autocorrection is imperfect, but it will be refined further up by other cops.
+      expect_correction(<<~RUBY)
+        [
+          1,#{trailing_whitespace}
+        2,#{trailing_whitespace}
+        3,
+        ]
+      RUBY
+    end
+  end
+
+  context 'when two elements on same line' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        [1,
+          2, 4]
+             ^ Each item in a multi-line array must start on a separate line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1,
+          2,\s
+        4]
+      RUBY
+    end
+  end
+
+  context 'when nested arrays' do
+    it 'registers an offense and corrects' do
+      expect_offense(<<~RUBY)
+        [1,
+          [2, 3], 4]
+                  ^ Each item in a multi-line array must start on a separate line.
+      RUBY
+
+      expect_correction(<<~RUBY)
+        [1,
+          [2, 3],\s
+        4]
+      RUBY
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'runger_style'
+Dir['spec/support/**/*.rb'].each { |file| require_relative "../#{file}" }
 
 RSpec.configure do |config|
   config.expect_with(:rspec) do |expectations|

--- a/spec/support/misc_helper.rb
+++ b/spec/support/misc_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# rubocop:disable Style/TopLevelMethodDefinition
+def trailing_whitespace
+  ' '
+end
+# rubocop:enable Style/TopLevelMethodDefinition


### PR DESCRIPTION
This change monkeypatches `RuboCop::Cop::MultilineElementLineBreaks` so that arrays will be considered multiline if the array brackets are on separate lines (even if all elements are on a single line).