### PR TITLE
[specs] Remove 'include RuboCop::RSpec::ExpectOffense' statements

### DIFF
--- a/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
@@ -4,8 +4,6 @@ require 'rubocop'
 require 'rubocop/rspec/support'
 
 RSpec.describe RuboCop::Cop::Layout::MultilineArrayLineBreaks, :config do
-  include RuboCop::RSpec::ExpectOffense
-
   context 'when on same line' do
     it 'does not add any offenses' do
       expect_no_offenses(<<~RUBY)

--- a/spec/runger_style/argument_alignment_spec.rb
+++ b/spec/runger_style/argument_alignment_spec.rb
@@ -4,8 +4,6 @@ require 'rubocop'
 require 'rubocop/rspec/support'
 
 RSpec.describe RungerStyle::ArgumentAlignment, :config do
-  include RuboCop::RSpec::ExpectOffense
-
   let(:cop_config) do
     {
       'EnforcedStyle' => style,

--- a/spec/runger_style/first_argument_indentation_spec.rb
+++ b/spec/runger_style/first_argument_indentation_spec.rb
@@ -4,8 +4,6 @@ require 'rubocop'
 require 'rubocop/rspec/support'
 
 RSpec.describe RungerStyle::FirstArgumentIndentation, :config do
-  include RuboCop::RSpec::ExpectOffense
-
   let(:cop_config) do
     {
       'EnforcedStyle' => style,

--- a/spec/runger_style/multiline_hash_value_indentation_spec.rb
+++ b/spec/runger_style/multiline_hash_value_indentation_spec.rb
@@ -4,8 +4,6 @@ require 'rubocop'
 require 'rubocop/rspec/support'
 
 RSpec.describe RungerStyle::MultilineHashValueIndentation do
-  include RuboCop::RSpec::ExpectOffense
-
   subject(:cop) { described_class.new }
 
   ruby_version =

--- a/spec/runger_style/multiline_method_arguments_line_breaks_spec.rb
+++ b/spec/runger_style/multiline_method_arguments_line_breaks_spec.rb
@@ -4,8 +4,6 @@ require 'rubocop'
 require 'rubocop/rspec/support'
 
 RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks do
-  include RuboCop::RSpec::ExpectOffense
-
   subject(:cop) { described_class.new }
 
   ruby_version =


### PR DESCRIPTION
They seem not to be needed? Maybe they were needed at some point in the past, but apparently they aren't needed any longer.