### PR TITLE
[specs] Use :config metadata setup helper

### DIFF
--- a/spec/runger_style/multiline_hash_value_indentation_spec.rb
+++ b/spec/runger_style/multiline_hash_value_indentation_spec.rb
@@ -3,9 +3,7 @@
 require 'rubocop'
 require 'rubocop/rspec/support'
 
-RSpec.describe RungerStyle::MultilineHashValueIndentation do
-  subject(:cop) { described_class.new }
-
+RSpec.describe RungerStyle::MultilineHashValueIndentation, :config do
   ruby_version =
     YAML.load_file(
       'rulesets/default.yml',
@@ -40,7 +38,7 @@ RSpec.describe RungerStyle::MultilineHashValueIndentation do
           bootstrap(
             gantt_chart_data_by_github_run_id:
             @ci_step_results_presenter.gantt_chart_metadatas,
-            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RungerStyle/MultilineHashValueIndentation: Hash value should be indented by two spaces relative to its key.
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Hash value should be indented by two spaces relative to its key.
           )
         RUBY
 
@@ -59,7 +57,7 @@ RSpec.describe RungerStyle::MultilineHashValueIndentation do
           bootstrap(
             gantt_chart_data_by_github_run_id:
                 @ci_step_results_presenter.gantt_chart_metadatas,
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RungerStyle/MultilineHashValueIndentation: Hash value should be indented by two spaces relative to its key.
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Hash value should be indented by two spaces relative to its key.
           )
         RUBY
 
@@ -78,7 +76,7 @@ RSpec.describe RungerStyle::MultilineHashValueIndentation do
           bootstrap(
             gantt_chart_data_by_github_run_id:
             some_other_method(
-            ^^^^^^^^^^^^^^^^^^ RungerStyle/MultilineHashValueIndentation: Hash value should be indented by two spaces relative to its key.
+            ^^^^^^^^^^^^^^^^^^ Hash value should be indented by two spaces relative to its key.
               an_argument,
             )
           )
@@ -118,7 +116,7 @@ RSpec.describe RungerStyle::MultilineHashValueIndentation do
               workers
             }x =>
             'the hash value',
-            ^^^^^^^^^^^^^^^^ RungerStyle/MultilineHashValueIndentation: Hash value should be indented by two spaces relative to its key.
+            ^^^^^^^^^^^^^^^^ Hash value should be indented by two spaces relative to its key.
           }.freeze
         RUBY
 

--- a/spec/runger_style/multiline_method_arguments_line_breaks_spec.rb
+++ b/spec/runger_style/multiline_method_arguments_line_breaks_spec.rb
@@ -3,9 +3,7 @@
 require 'rubocop'
 require 'rubocop/rspec/support'
 
-RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks do
-  subject(:cop) { described_class.new }
-
+RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks, :config do
   ruby_version =
     YAML.load_file(
       'rulesets/default.yml',
@@ -28,7 +26,7 @@ RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks do
         expect_offense(<<~RUBY)
           foo(
             a, b,
-             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+             ^^ Each argument in a multi-line method call must start on a separate line.
           )
         RUBY
 
@@ -46,7 +44,7 @@ RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks do
         expect_offense(<<~RUBY)
           foo(
             a:, b: 2,
-              ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+              ^^ Each argument in a multi-line method call must start on a separate line.
           )
         RUBY
 
@@ -74,8 +72,8 @@ RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks do
         expect_offense(<<~RUBY)
           foo(
             a, b, c,
-             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
-                ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+             ^^ Each argument in a multi-line method call must start on a separate line.
+                ^^ Each argument in a multi-line method call must start on a separate line.
           )
         RUBY
 
@@ -94,7 +92,7 @@ RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks do
         expect_offense(<<~RUBY)
           foo(
             a, b,
-             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+             ^^ Each argument in a multi-line method call must start on a separate line.
             c,
           )
         RUBY
@@ -144,7 +142,7 @@ RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks do
         expect_offense(<<~RUBY)
           foo(
             bar(a, b), c,
-                     ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+                     ^^ Each argument in a multi-line method call must start on a separate line.
           )
         RUBY
 
@@ -162,7 +160,7 @@ RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks do
         expect_offense(<<~RUBY)
           foo(
             a, b, # trailing comment
-             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+             ^^ Each argument in a multi-line method call must start on a separate line.
           )
         RUBY
 
@@ -180,7 +178,7 @@ RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks do
         expect_offense(<<~RUBY)
           foo.bar(
             a, b,
-             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+             ^^ Each argument in a multi-line method call must start on a separate line.
           )
         RUBY
 
@@ -198,7 +196,7 @@ RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks do
         expect_offense(<<~RUBY)
           foo(
             a, b,
-             ^^ RungerStyle/MultilineMethodArgumentsLineBreaks: Each argument in a multi-line method call must start on a separate line.
+             ^^ Each argument in a multi-line method call must start on a separate line.
           ) do |x|
             x.some_method
           end


### PR DESCRIPTION
A few advantages:

1. Don't need to explicitly define a `cop` subject
2. The error messages don't include the cop name, which makes them shorter and easier to read.
3. This might also make it easier to expand these specs with custom cop configuration (or for these specs to serve as a blueprint for other specs that might need custom cop configuration)