### PR TITLE
Disable 'Metrics/CyclomaticComplexity' cop [STYL-7]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Disable `Metrics/CyclomaticComplexity` cop.
 
 ## v5.1.0 (2025-02-12)
 - Monkeypatch `RuboCop::Cop::MultilineElementLineBreaks` so that arrays will be considered multiline if the array brackets are on separate lines (even if all elements are on a single line).

--- a/lib/runger_style/cops/multiline_method_arguments_line_breaks.rb
+++ b/lib/runger_style/cops/multiline_method_arguments_line_breaks.rb
@@ -8,7 +8,6 @@ module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
     MSG = 'Each argument in a multi-line method call must start on a separate line.'
 
     # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Metrics/CyclomaticComplexity
     def on_send(node)
       if node.arguments? && multiline_method_call?(node)
         # When a method call uses keyword arguments without braces,
@@ -35,7 +34,6 @@ module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
         end
       end
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
 
     private

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -84,6 +84,8 @@ Metrics/BlockLength:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
 Metrics/MethodLength:
   Max: 30
 Metrics/ModuleLength:


### PR DESCRIPTION
This change disables the `Metrics/CyclomaticComplexity` cop, which seems largely redundant with the Metrics/PerceivedComplexity cop. When one triggers, it seems that the other usually (though not always) does, too.

I somewhat question the value of these cops, in general (I think we as humans can tell when a method is getting complex, and I'm not sure we really need a cop to tell us), but I especially question the value of having basically two cops calling out the same thing. So, this change disables `Metrics/CyclomaticComplexity`, since I think that name is sort of annoying (at least relative to `Metrics/PerceivedComplexity`).

For now, I will leave Metrics/PerceivedComplexity enabled, though I'd be unsurprised if I eventually disable that one, too.