### PR TITLE
Require 'rubocop' and 'rubocop/rspec/support' in spec_helper.rb

### DIFF
--- a/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
+++ b/spec/rubocop/cop/layout/multiline_array_line_breaks_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'rubocop'
-require 'rubocop/rspec/support'
-
 RSpec.describe RuboCop::Cop::Layout::MultilineArrayLineBreaks, :config do
   context 'when on same line' do
     it 'does not add any offenses' do

--- a/spec/runger_style/argument_alignment_spec.rb
+++ b/spec/runger_style/argument_alignment_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'rubocop'
-require 'rubocop/rspec/support'
-
 RSpec.describe RungerStyle::ArgumentAlignment, :config do
   let(:cop_config) do
     {

--- a/spec/runger_style/first_argument_indentation_spec.rb
+++ b/spec/runger_style/first_argument_indentation_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'rubocop'
-require 'rubocop/rspec/support'
-
 RSpec.describe RungerStyle::FirstArgumentIndentation, :config do
   let(:cop_config) do
     {

--- a/spec/runger_style/multiline_hash_value_indentation_spec.rb
+++ b/spec/runger_style/multiline_hash_value_indentation_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'rubocop'
-require 'rubocop/rspec/support'
-
 RSpec.describe RungerStyle::MultilineHashValueIndentation, :config do
   ruby_version =
     YAML.load_file(

--- a/spec/runger_style/multiline_method_arguments_line_breaks_spec.rb
+++ b/spec/runger_style/multiline_method_arguments_line_breaks_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'rubocop'
-require 'rubocop/rspec/support'
-
 RSpec.describe RungerStyle::MultilineMethodArgumentsLineBreaks, :config do
   ruby_version =
     YAML.load_file(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'runger_style'
+require 'rubocop'
+require 'rubocop/rspec/support'
 Dir['spec/support/**/*.rb'].each { |file| require_relative "../#{file}" }
 
 RSpec.configure do |config|


### PR DESCRIPTION
... rather than needing to require them in each individual spec file.