### PR TITLE
Disable 'Rails/Delegate' cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Disable `Rails/Delegate` cop.
 
 ## v5.2.0 (2025-02-16)
 - Disable `Metrics/CyclomaticComplexity` cop.

--- a/rulesets/rails.yml
+++ b/rulesets/rails.yml
@@ -16,6 +16,8 @@ Rails/CreateTableWithTimestamps:
   Exclude:
     - !ruby/regexp /db/migrate/201[1-9].*\.rb\z/
     - db/schema.rb
+Rails/Delegate:
+  Enabled: false
 Rails/EnvironmentVariableAccess:
   AllowReads: true
 Rails/I18nLocaleTexts:


### PR DESCRIPTION
I have never really liked this rule. It's more intuitive for me to write, read, and step through a debugger when methods are written in the normal way, rather than using `delegate`. Maybe sometimes I will use `delegate`, but I don't want RuboCop to try to force me to always use it.