### PR TITLE
Register 'rubocop-performance' and 'rubocop-rake' as plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 - Disable `Rails/Delegate` cop.
 - Register `rubocop-rails` as a plugin (rather than requiring it).
+- Register `rubocop-performance` and `rubocop-rake` as plugins (rather than requiring them).
 
 ## v5.2.0 (2025-02-16)
 - Disable `Metrics/CyclomaticComplexity` cop.

--- a/rulesets/performance.yml
+++ b/rulesets/performance.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
 
 Performance/ChainArrayAllocation:

--- a/rulesets/rake.yml
+++ b/rulesets/rake.yml
@@ -1,2 +1,2 @@
-require:
+plugins:
   - rubocop-rake


### PR DESCRIPTION
... rather than `require`ing them.