### PR TITLE
Include rubocop-rspec as a plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Register `rubocop-rspec` as a plugin (rather than requiring it).
 
 ## v5.3.1 (2025-02-16)
 - Enforce `RungerStyle/ArgumentAlignment` on macro method calls with parentheses.

--- a/rulesets/rspec.yml
+++ b/rulesets/rspec.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-rspec
 
 RSpec/BeEq:


### PR DESCRIPTION
> rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /home/runner/work/runger_release_assistant/runger_release_assistant/vendor/bundle/ruby/3.4.0/gems/runger_style-5.3.1/rulesets/rspec.yml.

-- https://github.com/davidrunger/runger_release_assistant/actions/runs/13373699807/job/37348657507#step:4:5