### PR TITLE
Disable Capybara/AmbiguousClick, add RungerStyle/ClickAmbiguously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+- Disable `Capybara/AmbiguousClick` and `Capybara/ClickLinkOrButtonStyle` and add `RungerStyle/ClickAmbiguously`, which does the opposite of `Capybara/AmbiguousClick`, i.e. it requires the use of `click_on` and forbids the use of `click_button` or `click_link`.
+
 ### Internal
 - Move default custom cops and monkeypatches to `default/` subdirectory. This will make it possible to also add cops/monkeypatches for other plugins in other subdirectories (e.g. capybara) that we don't want to require/include in the default config.
 

--- a/lib/runger_style/cops/capybara/click_ambiguously.rb
+++ b/lib/runger_style/cops/capybara/click_ambiguously.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
+  class ClickAmbiguously < ::RuboCop::Cop::Base
+    extend ::RuboCop::Cop::AutoCorrector
+    MSG = 'Use `click_on` instead of `click_link` or `click_button`.'
+    RESTRICT_ON_SEND = %i[click_button click_link].freeze
+
+    def on_send(node)
+      add_offense(node) do |corrector|
+        corrector.replace(node.loc.selector, 'click_on')
+      end
+    end
+  end
+end

--- a/lib/runger_style/cops/capybara/require_all_custom_cops.rb
+++ b/lib/runger_style/cops/capybara/require_all_custom_cops.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Dir[File.expand_path('./**/*.rb', __dir__)].each do |file|
+  unless file == __FILE__
+    require file
+  end
+end

--- a/rulesets/capybara.yml
+++ b/rulesets/capybara.yml
@@ -1,7 +1,16 @@
+require:
+  - ../lib/runger_style/cops/capybara/require_all_custom_cops.rb
+
 plugins:
   - rubocop-capybara
 
+Capybara/AmbiguousClick:
+  Enabled: false
+Capybara/ClickLinkOrButtonStyle:
+  Enabled: false
 Capybara/NegationMatcher:
   EnforcedStyle: not_to
 Capybara/SpecificMatcher:
   Enabled: false
+RungerStyle/ClickAmbiguously:
+  Enabled: true


### PR DESCRIPTION
Disable `Capybara/AmbiguousClick` (which requires that `click_on` not be used, and `click_link` or `click_button` be used instead) and `Capybara/ClickLinkOrButtonStyle` (which is deprecated and planned for removal in the next major release of `rubocop-capybara`).

Instead, add my own cop, `RungerStyle/ClickAmbiguously`, which requires the use of `click_on` (and provides autocorrection for `click_link` and `click_button`).

Reasoning/motivation: I agree with this comment: https://github.com/rubocop/rubocop-capybara/pull/ 61#issuecomment-1740641746 .

> Can someone explain the rationale behind why using `click_link` and `click_button` is better than `click_link_or_button` and `click_on`? Maybe I'm missing something here, but I would have expected `click_on` and `click_link_or_button` to be better because your tests will be less tightly coupled to your HTML and it more closely reflects how a user would behave (there's no way a user can tell the difference between a button and a link styled to look like a button)

I understand that links and buttons are not the same and that there are certain times when each should be used, and that there are accessibility considerations, but I don't really think that my feature tests should be written with such things in mind. I like the simplicity of just writing `click_on` without needing to think about / figure out if it is a link or a button, and I like that the spec might continue to work in the expected way even if a button is changed to a link or vice versa.