### PR TITLE
Turn off warnings when running RSpec [STYL-9]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-[no unreleased changes yet]
+### Internal
+- Turn off warnings when running RSpec.
 
 ## v5.7.0 (2025-03-10)
 - Disable `Capybara/AmbiguousClick` and `Capybara/ClickLinkOrButtonStyle` and add `RungerStyle/ClickAmbiguously`, which does the opposite of `Capybara/AmbiguousClick`, i.e. it requires the use of `click_on` and forbids the use of `click_button` or `click_link`.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,8 @@ RSpec.configure do |config|
 
   config.disable_monkey_patching!
 
-  config.warnings = true
+  # Reenable warnings after https://github.com/rubocop/rubocop-rails/issues/1465 is fixed.
+  # config.warnings = true
 
   config.order = :random
 


### PR DESCRIPTION
We can reenable warnings after https://github.com/rubocop/rubocop-rails/issues/ 1465 is fixed.