### PR TITLE
Disable Metrics/PerceivedComplexity & Metrics/MethodLength [STYL-10]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+- Disable `Metrics/PerceivedComplexity` and `Metrics/MethodLength`.
+
 ### Internal
 - Turn off warnings when running RSpec.
 

--- a/lib/runger_style/cops/default/multiline_method_arguments_line_breaks.rb
+++ b/lib/runger_style/cops/default/multiline_method_arguments_line_breaks.rb
@@ -7,7 +7,6 @@ module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
 
     MSG = 'Each argument in a multi-line method call must start on a separate line.'
 
-    # rubocop:disable Metrics/PerceivedComplexity
     def on_send(node)
       if node.arguments? && multiline_method_call?(node)
         # When a method call uses keyword arguments without braces,
@@ -34,7 +33,6 @@ module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
         end
       end
     end
-    # rubocop:enable Metrics/PerceivedComplexity
 
     private
 

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -87,8 +87,10 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Enabled: false
 Metrics/MethodLength:
-  Max: 30
+  Enabled: false
 Metrics/ModuleLength:
+  Enabled: false
+Metrics/PerceivedComplexity:
   Enabled: false
 Naming/BlockForwarding:
   Enabled: false


### PR DESCRIPTION
I disable this cop a lot, and I'm not sure that I really need a cop to tell me when a method is getting complex. I think that heeding this cop can result in code changes such as method extraction or class extraction / composition that ultimately sometimes just make the code even harder to read (necessitating jumping around more, when a long/complex but at least self-contained procedural method could do the job).

Don't get me wrong, sometimes there are cases where method extraction and/or class extraction is helpful. But I don't think it always is helpful. Sometimes, I think that a relatively big and relatively complex method is the simplest way to go, on net.

But I haven't found much value at all in having this cop complain about methods with high perceived complexity, so I'm disabling it.