### PR TITLE
Allowlist find_by_hashid(!) for Rails/DynamicFindBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Disable `Metrics/PerceivedComplexity` and `Metrics/MethodLength`.
+- Allowlist `find_by_hashid` and `find_by_hashid!` for `Rails/DynamicFindBy`.
 
 ### Internal
 - Turn off warnings when running RSpec.

--- a/rulesets/rails.yml
+++ b/rulesets/rails.yml
@@ -18,6 +18,12 @@ Rails/CreateTableWithTimestamps:
     - db/schema.rb
 Rails/Delegate:
   Enabled: false
+Rails/DynamicFindBy:
+  AllowedMethods:
+    - find_by_hashid
+    - find_by_hashid!
+    - find_by_sql
+    - find_by_token_for
 Rails/EnvironmentVariableAccess:
   AllowReads: true
 Rails/I18nLocaleTexts:


### PR DESCRIPTION
https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsdynamicfindby
https://github.com/jcypret/hashid-rails

Also, continue to allowlist the default allowed methods (`find_by_sql` and `find_by_token_for`).