### PR TITLE
Remove check for alpha version from GitHub Action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,28 +12,34 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - name: Check out code
+      uses: actions/checkout@v4
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
+
     - name: Set up
       run: |
         gem install bundler -v 2.1.4
         bundle install --jobs 4 --retry 3
+
     - name: Run RuboCop
       run: bin/rubocop --format clang --color 2> >(tee /tmp/rubocop_stderr >&2)
+
     - name: Check that RuboCop didn't write anything to stderr
       run: |
         if [[ -s /tmp/rubocop_stderr ]] ; then
           echo "Error: stderr was not empty" >&2
           exit 1
         fi
+
     - name: Run RSpec tests
       run: bin/rspec --format progress
-    - name: Ensure alpha version
-      run: grep alpha $(find . -type f -name version.rb)
+
     - name: Ensure no git diff
       run: git diff --exit-code && git diff-index --quiet --cached HEAD
+
     - name: Ensure "## Unreleased" is in CHANGELOG.md
       run: grep "^## Unreleased" CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
-[no unreleased changes yet]
+### Internal
+- Remove check for alpha version from GitHub Action.
 
 ## v5.8.0 (2025-03-22)
 - Disable `Metrics/PerceivedComplexity` and `Metrics/MethodLength`.


### PR DESCRIPTION
The latest version of `runger_release_assistant` no longer bumps to an alpha version. https://github.com/davidrunger/runger_release_assistant/pull/576

Also, space each step with a newline between it and the preceding and following step(s).

Also, label the checkout step with a pretty name.