### PR TITLE
Reenable warnings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,8 +20,7 @@ RSpec.configure do |config|
 
   config.disable_monkey_patching!
 
-  # Reenable warnings after https://github.com/rubocop/rubocop-rails/issues/1465 is fixed.
-  # config.warnings = true
+  config.warnings = true
 
   config.order = :random
 


### PR DESCRIPTION
The recently released rubocop-rails version 2.31.0 https://github.com/rubocop/rubocop-rails/releases/tag/v2.31.0 includes fixes ( https://github.com/rubocop/rubocop-rails/issues/ 1466 , https://github.com/rubocop/rubocop-rails/pull/ 1467 ) so that the warnings that were being printed before when warnings were enabled will not be printed anymore.