### PR TITLE
Disable extension suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Disable extension suggestions.
 
 ## v5.8.2 (2025-06-04)
 - Update `Naming/PredicateName` cop name to `Naming/PredicatePrefix`.

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -4,6 +4,7 @@ require:
 AllCops:
   EnabledByDefault: true
   ParserEngine: parser_prism
+  SuggestExtensions: false
   TargetRubyVersion: 3.4
   UseCache: true
 Bundler/GemComment:


### PR DESCRIPTION
This removes cluttering and relatively low value output like seen below when running RuboCop:

```
~/code/runger_email_reply_trimmer  use-local-runger_style ✔ 1↥  09:26:54 AM
❯ cop -A
Inspecting 15 files
...............

15 files inspected, no offenses detected

Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-minitest (https://rubygems.org/gems/rubocop-minitest)
  * rubocop-rake (https://rubygems.org/gems/rubocop-rake)

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```