### PR TITLE
[Layout/LineLength] Allow AnnotateRb index comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- [default] Allow long AnnotateRb index comments for custom and regular index names.
 
 ## v5.13.2 (2026-06-23)
 - [capybara] Delete disablement of removed `Capybara/ClickLinkOrButtonStyle` rule.

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -51,8 +51,8 @@ Layout/LineLength:
     # Ignore line length if the line is a comment without any spaces; it's probably not something we
     # can fix (e.g. a long file path):
     - !ruby/regexp /^ *#? [\S]+$/
-    # Ignore long annotate comments about indexes.
-    - !ruby/regexp /^#\s+idx_on_/
+    # Ignore long AnnotateRb comments about indexes.
+    - !ruby/regexp /^# {2}\S+\s+\(.+\).*$/
     # Ignore RSpec description strings:
     - !ruby/regexp /^ *(context|describe|it) ['"].*['"].* do$/
   Max: 100

--- a/spec/rubocop/cop/layout/line_length_spec.rb
+++ b/spec/rubocop/cop/layout/line_length_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Layout::LineLength, :config do
+  let(:cop_config) do
+    YAML.load_file(
+      'rulesets/default.yml',
+      permitted_classes: [Regexp],
+    ).fetch(described_class.cop_name)
+  end
+
+  it 'allows a long AnnotateRb comment for a custom partial index' do
+    expect_no_offenses(<<~RUBY)
+      #  uniq_pending_proposals  (proposer_id,proposee_email) UNIQUE WHERE ((accepted_at IS NULL) AND (canceled_at IS NULL))
+    RUBY
+  end
+
+  it 'allows a long AnnotateRb comment for a regular index' do
+    expect_no_offenses(<<~RUBY)
+      #  index_proposals_on_proposer_id_and_proposee_email_and_created_at (proposer_id,proposee_email,created_at)
+    RUBY
+  end
+
+  it 'does not allow an index-like comment with only one space after the comment marker' do
+    expect_offense(<<~RUBY)
+      # index_proposals_on_proposer_id_and_proposee_email_and_created_at  (proposer_id,proposee_email,created_at)
+                                                                                                          ^^^^^^^ Line is too long. [107/100]
+    RUBY
+  end
+
+  it 'does not allow an unrelated long comment' do
+    expect_offense(<<~RUBY)
+      # This unrelated prose comment is intentionally made longer than one hundred characters so that it remains an offense.
+                                                                                                          ^^^^^^^^^^^^^^^^^^ Line is too long. [118/100]
+    RUBY
+  end
+end


### PR DESCRIPTION
Broaden the existing AnnotateRb index-comment exception beyond Rails-generated idx_on_ names. Match the generated index annotation structure so custom names and partial-index predicates can exceed the normal line limit without requiring edits to generated comments.

Exercise the configured Layout/LineLength cop with regular and custom partial index annotations, and verify that an unrelated long prose comment remains an offense.