### PR TITLE
[ArgumentAlignment] Fix macro indentation [STYL-11]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- [default] Enforce fixed continuation indentation for parenthesis-free macro calls.
 
 ## v5.14.0 (2026-08-11)
 - [default] Allow long AnnotateRb index comments for custom and regular index names.

--- a/lib/runger_style/cops/default/argument_alignment.rb
+++ b/lib/runger_style/cops/default/argument_alignment.rb
@@ -3,9 +3,22 @@
 module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
   class ArgumentAlignment < ::RuboCop::Cop::Layout::ArgumentAlignment
     def on_send(node)
-      return if node.macro? && !node.parenthesized_call?
+      previous_fixed_indentation = @fixed_indentation
+      @fixed_indentation = node.macro? && !node.parenthesized_call?
 
       super
+    ensure
+      @fixed_indentation = previous_fixed_indentation
+    end
+
+    private
+
+    def fixed_indentation?
+      @fixed_indentation || super
+    end
+
+    def with_first_argument_style?
+      !@fixed_indentation && super
     end
   end
 end

--- a/spec/runger_style/argument_alignment_spec.rb
+++ b/spec/runger_style/argument_alignment_spec.rb
@@ -12,33 +12,68 @@ RSpec.describe RungerStyle::ArgumentAlignment, :config do
     let(:style) { 'with_first_argument' }
 
     context 'when the method being called is a macro' do
-      context 'when multiline arguments are not aligned' do
-        context 'when called without parens' do
-          it 'accepts any indentation of the second argument' do
-            expect_no_offenses(<<~RUBY)
-              get 'some stuff',
-                'and more stuff'
-            RUBY
-          end
+      context 'when called without parens' do
+        it 'accepts fixed indentation of subsequent arguments' do
+          expect_no_offenses(<<~RUBY)
+            get 'some stuff',
+              'and more stuff'
+          RUBY
         end
 
-        context 'when called with parens' do
-          it 'complains and corrects it' do
-            expect_offense(<<~RUBY)
-              create(
-                :ci_step_result,
-              :cpu_time,
-              ^^^^^^^^^ Align the arguments of a method call if they span more than one line.
-              )
-            RUBY
+        it 'complains and corrects inconsistent indentation' do
+          expect_offense(<<~RUBY)
+            class User
+              validates :initial_ip,
+            :latest_ip,
+            ^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+            :initial_user_agent,
+            ^^^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+            :latest_user_agent,
+            ^^^^^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+                :last_active_at,
+            presence: true
+            ^^^^^^^^^^^^^^ Use one level of indentation for arguments following the first line of a multi-line method call.
+            end
+          RUBY
 
-            expect_correction(<<~RUBY)
-              create(
-                :ci_step_result,
-                :cpu_time,
-              )
-            RUBY
-          end
+          expect_correction(<<~RUBY)
+            class User
+              validates :initial_ip,
+                :latest_ip,
+                :initial_user_agent,
+                :latest_user_agent,
+                :last_active_at,
+                presence: true
+            end
+          RUBY
+        end
+      end
+
+      context 'when called with parens' do
+        it 'accepts alignment with the first argument' do
+          expect_no_offenses(<<~RUBY)
+            create(
+              :ci_step_result,
+              :cpu_time,
+            )
+          RUBY
+        end
+
+        it 'complains and corrects misalignment with the first argument' do
+          expect_offense(<<~RUBY)
+            create(
+              :ci_step_result,
+            :cpu_time,
+            ^^^^^^^^^ Align the arguments of a method call if they span more than one line.
+            )
+          RUBY
+
+          expect_correction(<<~RUBY)
+            create(
+              :ci_step_result,
+              :cpu_time,
+            )
+          RUBY
         end
       end
     end


### PR DESCRIPTION
Parenthesis-free macro calls are exempt from parentheses, so aligning continuation arguments with the first argument produces excessive indentation. The previous macro exemption skipped alignment entirely and allowed inconsistent indentation.

Select the superclass fixed-indentation behavior while `RungerStyle/ArgumentAlignment` processes a parenthesis-free macro. This retains RuboCop’s keyword-hash handling and autocorrection while preserving `with_first_argument` alignment for parenthesized macros and ordinary method calls.

Document the new default behavior in `CHANGELOG.md`.