### PR TITLE
[cops/default] Prohibit trailing conditionals [STYL-12]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- [default] Add `RungerStyle/IfUnlessModifier` to prohibit trailing `if` and `unless` conditions.
 
 ## v5.14.1 (2026-08-13)
 - [default] Enforce fixed continuation indentation for parenthesis-free macro calls.

--- a/lib/runger_style/cops/default/first_argument_indentation.rb
+++ b/lib/runger_style/cops/default/first_argument_indentation.rb
@@ -3,9 +3,9 @@
 module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
   class FirstArgumentIndentation < ::RuboCop::Cop::Layout::FirstArgumentIndentation
     def on_send(node)
-      return if memoizing?(node)
-
-      super
+      unless memoizing?(node)
+        super
+      end
     end
 
     private

--- a/lib/runger_style/cops/default/if_unless_modifier.rb
+++ b/lib/runger_style/cops/default/if_unless_modifier.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
+  class IfUnlessModifier < ::RuboCop::Cop::Base
+    extend ::RuboCop::Cop::AutoCorrector
+    include ::RuboCop::Cop::RangeHelp
+
+    MSG = 'Use a multiline conditional instead of a trailing `%<keyword>s` condition.'
+
+    def on_if(node)
+      if node.modifier_form?
+        comment = trailing_comment(node)
+
+        add_offense(node.loc.keyword, message: format(MSG, keyword: node.keyword)) do |corrector|
+          corrector.replace(node, replacement(node, comment))
+
+          if comment
+            corrector.remove(trailing_comment_range(node, comment))
+          end
+        end
+      end
+    end
+
+    private
+
+    def replacement(node, comment)
+      indentation = node.source_range.source_line[/^\s*/]
+
+      <<~RUBY.chomp
+        #{node.keyword} #{node.condition.source}#{comment_suffix(comment)}
+        #{indented_body(node, indentation)}
+        #{indentation}end
+      RUBY
+    end
+
+    def indented_body(node, indentation)
+      node.body.source.lines.map.with_index do |line, index|
+        index.zero? ? "#{indentation}  #{line}" : "  #{line}"
+      end.join
+    end
+
+    def trailing_comment(node)
+      processed_source.comments.find do |comment|
+        comment.location.line == node.last_line &&
+          comment.source_range.begin_pos >= node.source_range.end_pos
+      end
+    end
+
+    def comment_suffix(comment)
+      if comment
+        " #{comment.source}"
+      else
+        ''
+      end
+    end
+
+    def trailing_comment_range(node, comment)
+      range_between(node.source_range.end_pos, comment.source_range.end_pos)
+    end
+  end
+end

--- a/lib/runger_style/cops/default/monkeypatches/multiline_element_line_breaks.rb
+++ b/lib/runger_style/cops/default/monkeypatches/multiline_element_line_breaks.rb
@@ -4,16 +4,16 @@ module RungerStyle::MultilineElementLineBreaksPatches
   private
 
   def check_line_breaks(node, children, ignore_last: false)
-    return if single_line?(node, children, ignore_last:)
-
-    last_seen_line = -1
-    children.each do |child|
-      if last_seen_line >= child.first_line
-        add_offense(child) do |corrector|
-          RuboCop::Cop::EmptyLineCorrector.insert_before(corrector, child)
+    unless single_line?(node, children, ignore_last:)
+      last_seen_line = -1
+      children.each do |child|
+        if last_seen_line >= child.first_line
+          add_offense(child) do |corrector|
+            RuboCop::Cop::EmptyLineCorrector.insert_before(corrector, child)
+          end
+        else
+          last_seen_line = child.last_line
         end
-      else
-        last_seen_line = child.last_line
       end
     end
   end

--- a/spec/runger_style/if_unless_modifier_spec.rb
+++ b/spec/runger_style/if_unless_modifier_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe RungerStyle::IfUnlessModifier, :config do
+  it 'accepts multiline if and unless conditionals' do
+    expect_no_offenses(<<~RUBY)
+      if ready?
+        start
+      end
+
+      unless stopped?
+        continue
+      end
+    RUBY
+  end
+
+  it 'complains about and corrects a trailing if condition' do
+    expect_offense(<<~RUBY)
+      start if ready?
+            ^^ Use a multiline conditional instead of a trailing `if` condition.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if ready?
+        start
+      end
+    RUBY
+  end
+
+  it 'complains about and corrects a trailing unless condition' do
+    expect_offense(<<~RUBY)
+      continue unless stopped?
+               ^^^^^^ Use a multiline conditional instead of a trailing `unless` condition.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      unless stopped?
+        continue
+      end
+    RUBY
+  end
+
+  it 'preserves a trailing comment with the condition' do
+    expect_offense(<<~RUBY)
+      enable_coverage(:branch) if !SpecHelper.is_ci? # Codecov doesn't respect
+                               ^^ Use a multiline conditional instead of a trailing `if` condition.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if !SpecHelper.is_ci? # Codecov doesn't respect
+        enable_coverage(:branch)
+      end
+    RUBY
+  end
+
+  it 'indents multiline guarded code' do
+    expect_offense(<<~RUBY)
+      perform(
+        first_argument,
+        second_argument,
+      ) if ready?
+        ^^ Use a multiline conditional instead of a trailing `if` condition.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if ready?
+        perform(
+          first_argument,
+          second_argument,
+        )
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Add `RungerStyle/IfUnlessModifier` to flag modifier-form `if` and `unless` nodes. Its autocorrection expands each modifier into a normal conditional, preserves indentation for multiline guarded expressions, and moves trailing comments to the generated condition line.

The default configuration enables the cop through `AllCops: EnabledByDefault`. Document the default-ruleset change and update existing library modifier conditionals so the package complies with its own configuration.

Cover accepted normal conditionals plus `if`, `unless`, trailing-comment, and multiline-body corrections in the cop spec.