### PR TITLE
[cops/default] Require empty lines after macro groups [STYL-14]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- [default] Add `RungerStyle/EmptyLineAfterMacro` to require an empty line after a group of macro calls.
 
 ## v5.15.0 (2026-08-20)
 - [default] Add `RungerStyle/IfUnlessModifier` to prohibit trailing `if` and `unless` conditions.

--- a/lib/runger_style/cops/default/empty_line_after_macro.rb
+++ b/lib/runger_style/cops/default/empty_line_after_macro.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
+  class EmptyLineAfterMacro < ::RuboCop::Cop::Base
+    extend ::RuboCop::Cop::AutoCorrector
+    include ::RuboCop::Cop::RangeHelp
+
+    MSG = 'Add an empty line after a macro call.'
+
+    def on_begin(node)
+      unless class_or_module_scope?(node)
+        return
+      end
+
+      node.children.each_cons(2) do |previous_node, next_node|
+        macro_call = macro_call_node(previous_node)
+        next_macro_call = macro_call_node(next_node)
+
+        if macro_call && !next_macro_call && !empty_line_between?(previous_node, next_node)
+          add_offense(macro_call.loc.selector, message: MSG) do |corrector|
+            autocorrect(corrector, previous_node, next_node)
+          end
+        end
+      end
+    end
+
+    private
+
+    def macro_call_node(node)
+      method_call = node
+      if node.any_block_type?
+        method_call = node.send_node
+      end
+
+      if method_call.send_type? && macro_call?(method_call)
+        return method_call
+      end
+
+      nil
+    end
+
+    def macro_call?(node)
+      node.macro? || node.self_receiver?
+    end
+
+    def class_or_module_scope?(node)
+      node.each_ancestor.any? do |ancestor|
+        ancestor.class_type? || ancestor.module_type? || ancestor.sclass_type?
+      end
+    end
+
+    def empty_line_between?(previous_node, next_node)
+      first_line = previous_node.source_range.last_line
+      last_line = next_node.source_range.first_line - 1
+
+      processed_source.lines[first_line...last_line].any?(&:blank?)
+    end
+
+    def autocorrect(corrector, previous_node, next_node)
+      if previous_node.source_range.last_line == next_node.source_range.first_line
+        corrector.replace(
+          range_between(previous_node.source_range.end_pos, next_node.source_range.begin_pos),
+          "\n\n",
+        )
+      else
+        corrector.insert_after(range_by_whole_lines(previous_node.source_range), "\n")
+      end
+    end
+  end
+end

--- a/spec/runger_style/empty_line_after_macro_spec.rb
+++ b/spec/runger_style/empty_line_after_macro_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+RSpec.describe RungerStyle::EmptyLineAfterMacro, :config do
+  it 'accepts a macro call followed by the class-closing end' do
+    expect_no_offenses(<<~RUBY)
+      class QuizParticipation < ApplicationRecord
+        has_many :quiz_question_answer_selections
+      end
+    RUBY
+  end
+
+  it 'accepts a macro call separated from a method definition' do
+    expect_no_offenses(<<~RUBY)
+      class QuizParticipation < ApplicationRecord
+        has_many :quiz_question_answer_selections
+
+        def correct_answer_count
+          quiz_question_answer_selections.count { it.answer.is_correct? }
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts consecutive macro calls before a method definition' do
+    expect_no_offenses(<<~RUBY)
+      class QuizParticipation < ApplicationRecord
+        has_many :quiz_question_answer_selections
+        belongs_to :something_else
+
+        def correct_answer_count
+          quiz_question_answer_selections.count { it.answer.is_correct? }
+        end
+      end
+    RUBY
+  end
+
+  it 'accepts a self-receiver macro grouped with other macro calls' do
+    expect_no_offenses(<<~RUBY)
+      class EmojiPickerController < ApplicationController
+        skip_before_action :authenticate_user!
+        self.container_classes = %w[p-8]
+
+        def index
+          render :index
+        end
+      end
+    RUBY
+  end
+
+  it 'does not group calls on other receivers with macro calls' do
+    expect_offense(<<~RUBY)
+      class EmojiPickerController < ApplicationController
+        skip_before_action :authenticate_user!
+        ^^^^^^^^^^^^^^^^^^ Add an empty line after a macro call.
+        config.container_classes = %w[p-8]
+
+        def index
+          render :index
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class EmojiPickerController < ApplicationController
+        skip_before_action :authenticate_user!
+
+        config.container_classes = %w[p-8]
+
+        def index
+          render :index
+        end
+      end
+    RUBY
+  end
+
+  it 'complains about and corrects a macro call before a method definition' do
+    expect_offense(<<~RUBY)
+      class QuizParticipation < ApplicationRecord
+        has_many :quiz_question_answer_selections
+        ^^^^^^^^ Add an empty line after a macro call.
+        def correct_answer_count
+          quiz_question_answer_selections.count { it.answer.is_correct? }
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class QuizParticipation < ApplicationRecord
+        has_many :quiz_question_answer_selections
+
+        def correct_answer_count
+          quiz_question_answer_selections.count { it.answer.is_correct? }
+        end
+      end
+    RUBY
+  end
+
+  it 'requires an empty line before other class-body code' do
+    expect_offense(<<~RUBY)
+      class QuizParticipation < ApplicationRecord
+        has_many :quiz_question_answer_selections
+        ^^^^^^^^ Add an empty line after a macro call.
+        ANSWER_COUNT = 1
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class QuizParticipation < ApplicationRecord
+        has_many :quiz_question_answer_selections
+
+        ANSWER_COUNT = 1
+      end
+    RUBY
+  end
+
+  it 'preserves a trailing comment on the macro call' do
+    expect_offense(<<~RUBY)
+      class QuizParticipation < ApplicationRecord
+        has_many :quiz_question_answer_selections # Associations
+        ^^^^^^^^ Add an empty line after a macro call.
+        def correct_answer_count
+        end
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      class QuizParticipation < ApplicationRecord
+        has_many :quiz_question_answer_selections # Associations
+
+        def correct_answer_count
+        end
+      end
+    RUBY
+  end
+
+  it 'does not treat ordinary calls outside a class or module as macros' do
+    expect_no_offenses(<<~RUBY)
+      require 'runger_style'
+      require 'rubocop'
+    RUBY
+  end
+
+  it 'does not treat calls inside method bodies as macros' do
+    expect_no_offenses(<<~RUBY)
+      class QuizParticipation < ApplicationRecord
+        def correct_answer_count
+          configure
+          result = 1
+        end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Add `RungerStyle/EmptyLineAfterMacro` to separate the final implicit-receiver or explicit-`self` macro in a `class` or `module` body from following non-macro code. Autocorrection inserts one blank line while preserving macro lines and trailing comments.

Keep consecutive macro calls grouped, including different methods such as `has_many` and `belongs_to`, and allow a macro as the final statement before the class-closing `end`. Document the new default rule in `CHANGELOG.md`.

codex resume 01a0255d-9ba9-76a0-b05f-9fd89a02e7d3