### PR TITLE
[cops/default] Avoid method-body false positives [STYL-15]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- [default] Fix false positives from `RungerStyle/EmptyLineAfterMacro` inside method bodies.
 
 ## v5.16.0 (2026-08-21)
 - [default] Add `RungerStyle/EmptyLineAfterMacro` to require an empty line after a group of macro calls.

--- a/lib/runger_style/cops/default/empty_line_after_macro.rb
+++ b/lib/runger_style/cops/default/empty_line_after_macro.rb
@@ -44,9 +44,7 @@ module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
     end
 
     def class_or_module_scope?(node)
-      node.each_ancestor.any? do |ancestor|
-        ancestor.class_type? || ancestor.module_type? || ancestor.sclass_type?
-      end
+      node.parent&.class_type? || node.parent&.module_type? || node.parent&.sclass_type?
     end
 
     def empty_line_between?(previous_node, next_node)

--- a/spec/runger_style/empty_line_after_macro_spec.rb
+++ b/spec/runger_style/empty_line_after_macro_spec.rb
@@ -150,4 +150,39 @@ RSpec.describe RungerStyle::EmptyLineAfterMacro, :config do
       end
     RUBY
   end
+
+  it 'does not treat setter calls inside instance methods as macros' do
+    expect_no_offenses(<<~RUBY)
+      class ApplicationCable::Connection < ActionCable::Connection::Base
+        def connect
+          self.current_user = find_verified_user
+          AuthenticatedSessions::Registry.current(request.session, :user)
+        end
+      end
+    RUBY
+  end
+
+  it 'does not treat setter calls inside singleton methods as macros' do
+    expect_no_offenses(<<~RUBY)
+      class ApplicationCable::Connection < ActionCable::Connection::Base
+        def self.connect
+          self.current_user = find_verified_user
+          AuthenticatedSessions::Registry.current(request.session, :user)
+        end
+      end
+    RUBY
+  end
+
+  it 'does not treat setter calls inside methods in a singleton class as macros' do
+    expect_no_offenses(<<~RUBY)
+      class ApplicationCable::Connection < ActionCable::Connection::Base
+        class << self
+          def connect
+            self.current_user = find_verified_user
+            AuthenticatedSessions::Registry.current(request.session, :user)
+          end
+        end
+      end
+    RUBY
+  end
 end


### PR DESCRIPTION
Restrict `class_or_module_scope?` to `begin` nodes whose immediate parent is a `class`, `module`, or `sclass` node. This prevents `RungerStyle/EmptyLineAfterMacro` from interpreting setter calls in instance and singleton method bodies as class-level macros while retaining class-body `self` assignments.

Add regression coverage for `def`, `def self`, and `class << self` method definitions, and document the fix in `CHANGELOG.md`.

codex resume 01a025a0-13c5-7231-a9a5-69aa2a2b6dd6