### PR TITLE
[cops/default] Forbid explicit returns [STYL-13]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- [default] Add report-only `RungerStyle/NoReturn` to forbid explicit `return` statements.
 
 ## v5.16.1 (2026-08-21)
 - [default] Fix false positives from `RungerStyle/EmptyLineAfterMacro` inside method bodies.

--- a/lib/runger_style/cops/default/empty_line_after_macro.rb
+++ b/lib/runger_style/cops/default/empty_line_after_macro.rb
@@ -8,17 +8,15 @@ module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
     MSG = 'Add an empty line after a macro call.'
 
     def on_begin(node)
-      unless class_or_module_scope?(node)
-        return
-      end
+      if class_or_module_scope?(node)
+        node.children.each_cons(2) do |previous_node, next_node|
+          macro_call = macro_call_node(previous_node)
+          next_macro_call = macro_call_node(next_node)
 
-      node.children.each_cons(2) do |previous_node, next_node|
-        macro_call = macro_call_node(previous_node)
-        next_macro_call = macro_call_node(next_node)
-
-        if macro_call && !next_macro_call && !empty_line_between?(previous_node, next_node)
-          add_offense(macro_call.loc.selector, message: MSG) do |corrector|
-            autocorrect(corrector, previous_node, next_node)
+          if macro_call && !next_macro_call && !empty_line_between?(previous_node, next_node)
+            add_offense(macro_call.loc.selector, message: MSG) do |corrector|
+              autocorrect(corrector, previous_node, next_node)
+            end
           end
         end
       end
@@ -33,10 +31,8 @@ module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
       end
 
       if method_call.send_type? && macro_call?(method_call)
-        return method_call
+        method_call
       end
-
-      nil
     end
 
     def macro_call?(node)

--- a/lib/runger_style/cops/default/no_return.rb
+++ b/lib/runger_style/cops/default/no_return.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
+  class NoReturn < ::RuboCop::Cop::Base
+    MSG = 'Do not use `return`.'
+
+    def on_return(node)
+      add_offense(node.loc.keyword, message: MSG)
+    end
+  end
+end

--- a/spec/runger_style/no_return_spec.rb
+++ b/spec/runger_style/no_return_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe RungerStyle::NoReturn, :config do
+  it 'accepts methods that use implicit returns' do
+    expect_no_offenses(<<~RUBY)
+      def answer
+        42
+      end
+    RUBY
+  end
+
+  it 'reports explicit returns without autocorrecting them' do
+    expect_offense(<<~RUBY)
+      def answer(value)
+        if value
+          return value
+          ^^^^^^ Do not use `return`.
+        else
+          nil
+        end
+      end
+    RUBY
+
+    expect_no_corrections
+  end
+
+  it 'reports returns without an argument and returns inside blocks' do
+    expect_offense(<<~RUBY)
+      def answer(value)
+        return unless value
+        ^^^^^^ Do not use `return`.
+
+        [value].each { return }
+                       ^^^^^^ Do not use `return`.
+      end
+    RUBY
+  end
+
+  it 'ignores return in comments and strings' do
+    expect_no_offenses(<<~RUBY)
+      # return an answer
+      message = 'return an answer'
+    RUBY
+  end
+end


### PR DESCRIPTION
Add `RungerStyle/NoReturn` to report every explicit `return` keyword while intentionally providing no autocorrection. Replacing an early exit with branching control flow is not generally safe to automate because the equivalent structure depends on surrounding conditionals, blocks, and method state.

Rewrite the internal `return` statements in `RungerStyle/EmptyLineAfterMacro` into equivalent branching and implicit-result code so the gem continues to satisfy its own default ruleset. Add focused coverage for implicit returns, explicit returns with and without arguments, block returns, comments, strings, and the report-only behavior. Document the new default cop in `CHANGELOG.md`.

codex resume 01a02716-eefa-7ae3-b0da-85b81501f6e3