### PR TITLE
[cops/default] Require multiline condition parentheses [STYL-16]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- [default] Add `RungerStyle/ParenthesesAroundMultilineCondition` to require parentheses around multiline `if`, `unless`, and `elsif` conditions, except for multiline block conditions and parenthesized receivers.
 
 ## v5.17.0 (2026-08-21)
 - [default] Add report-only `RungerStyle/NoReturn` to forbid explicit `return` statements.

--- a/lib/runger_style/cops/default/multiline_method_arguments_line_breaks.rb
+++ b/lib/runger_style/cops/default/multiline_method_arguments_line_breaks.rb
@@ -12,9 +12,11 @@ module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
         # When a method call uses keyword arguments without braces,
         # the parser produces a single hash node. In that case, inspect its pairs.
         arguments =
-          if node.arguments.one? &&
+          if (
+            node.arguments.one? &&
               node.arguments.first.hash_type? &&
               !node.arguments.first.braces?
+          )
             node.arguments.first.pairs
           else
             node.arguments

--- a/lib/runger_style/cops/default/parentheses_around_multiline_condition.rb
+++ b/lib/runger_style/cops/default/parentheses_around_multiline_condition.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
+  class ParenthesesAroundMultilineCondition < ::RuboCop::Cop::Base
+    extend ::RuboCop::Cop::AutoCorrector
+    include ::RuboCop::Cop::RangeHelp
+
+    MSG = 'Wrap multiline `%<keyword>s` conditions in parentheses.'
+
+    def on_if(node)
+      if offense?(node)
+        add_offense(node.loc.keyword, message: format(MSG, keyword: node.keyword)) do |corrector|
+          autocorrect(corrector, node)
+        end
+      end
+    end
+
+    private
+
+    def offense?(node)
+      multiline_conditional?(node) &&
+        !permitted_multiline_condition?(node) &&
+        !correctly_parenthesized?(node)
+    end
+
+    def correctly_parenthesized?(node)
+      inner_condition = parenthesized_condition(node.condition)
+
+      if inner_condition
+        condition_starts_on_next_line?(node, inner_condition) &&
+          closing_parenthesis_on_own_line?(node.condition, inner_condition)
+      end
+    end
+
+    def multiline_conditional?(node)
+      !node.modifier_form? && !node.ternary? && node.condition.multiline?
+    end
+
+    def permitted_multiline_condition?(node)
+      condition = node.condition
+
+      condition.any_block_type? || multiline_parenthesized_receiver?(condition)
+    end
+
+    def multiline_parenthesized_receiver?(condition)
+      if condition.send_type? || condition.csend_type?
+        receiver = condition.receiver
+        receiver&.begin_type? && receiver.multiline?
+      end
+    end
+
+    def autocorrect(corrector, node)
+      condition = node.condition
+      inner_condition = parenthesized_condition(condition)
+      condition_start =
+        if inner_condition
+          inner_condition.source_range.begin_pos
+        else
+          condition.source_range.begin_pos
+        end
+
+      if inner_condition
+        if !condition_starts_on_next_line?(node, inner_condition)
+          corrector.replace(
+            range_between(node.loc.keyword.end_pos, condition_start),
+            " (\n#{condition_indentation(node)}",
+          )
+        end
+
+        if !closing_parenthesis_on_own_line?(condition, inner_condition)
+          corrector.replace(
+            range_between(inner_condition.source_range.end_pos, condition.loc.end.end_pos),
+            "\n#{base_indentation(node)})",
+          )
+        end
+      else
+        corrector.replace(
+          range_between(node.loc.keyword.end_pos, condition_start),
+          " (\n#{condition_indentation(node)}",
+        )
+
+        condition_end = condition_end_position(condition)
+        corrector.insert_after(
+          range_between(condition_end, condition_end),
+          "\n#{base_indentation(node)})",
+        )
+      end
+    end
+
+    def condition_starts_on_next_line?(node, inner_condition)
+      inner_condition.first_line > node.loc.keyword.line
+    end
+
+    def closing_parenthesis_on_own_line?(condition, inner_condition)
+      condition.loc.end.line > inner_condition.source_range.last_line
+    end
+
+    def parenthesized_condition(condition)
+      if (
+        condition.begin_type? &&
+          condition.children.one? &&
+          condition.loc.begin &&
+          condition.loc.end
+      )
+        condition.children.first
+      end
+    end
+
+    def condition_end_position(condition)
+      end_position = condition.source_range.end_pos
+      last_line = condition.source_range.last_line
+
+      processed_source.comments.each do |comment|
+        if comment.location.line == last_line && comment.source_range.begin_pos >= end_position
+          end_position = comment.source_range.end_pos
+        end
+      end
+
+      end_position
+    end
+
+    def base_indentation(node)
+      node.loc.keyword.source_line[/\A[ \t]*/]
+    end
+
+    def condition_indentation(node)
+      base_indentation(node) + (' ' * indentation_width)
+    end
+
+    def indentation_width
+      config.for_cop('Layout/IndentationWidth')['Width'] || 2
+    end
+  end
+end

--- a/spec/runger_style/parentheses_around_multiline_condition_spec.rb
+++ b/spec/runger_style/parentheses_around_multiline_condition_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+RSpec.describe RungerStyle::ParenthesesAroundMultilineCondition, :config do
+  it 'accepts single-line conditions' do
+    expect_no_offenses(<<~RUBY)
+      if ready?
+        start
+      end
+
+      unless stopped?
+        continue
+      end
+
+      if ready?
+        start
+      elsif stopped?
+        stop
+      end
+    RUBY
+  end
+
+  it 'accepts multiline conditions with the condition on the next line' do
+    expect_no_offenses(<<~RUBY)
+      if (
+        normalized_url &&
+          visited_sitemap_urls.exclude?(normalized_url)
+      )
+        visited_sitemap_urls.add(normalized_url)
+      end
+
+      unless (
+        normalized_url &&
+          visited_sitemap_urls.exclude?(normalized_url)
+      )
+        visited_sitemap_urls.add(normalized_url)
+      end
+
+      if ready?
+        visit
+      elsif (
+        normalized_url &&
+          visited_sitemap_urls.exclude?(normalized_url)
+      )
+        visited_sitemap_urls.add(normalized_url)
+      end
+    RUBY
+  end
+
+  it 'accepts a multiline parenthesized receiver in a condition' do
+    expect_no_offenses(<<~RUBY)
+      if (
+        auth_token = potentially_unauthorized_auth_token_matching_secret
+      )&.valid_for?(controller_action)
+        auth_token
+      end
+    RUBY
+  end
+
+  it 'accepts a multiline block as a condition' do
+    expect_no_offenses(<<~RUBY)
+      if examples.any? do |example|
+        example.metadata[:type] == :feature && !example.metadata[:rack_test_driver]
+      end
+        prewarm_driver(Cuprite::CustomDrivers::DOMAIN_RESTRICTED_CUPRITE)
+      end
+    RUBY
+  end
+
+  it 'wraps a multiline if condition in parentheses' do
+    expect_offense(<<~RUBY)
+      if normalized_url &&
+      ^^ Wrap multiline `if` conditions in parentheses.
+          visited_sitemap_urls.exclude?(normalized_url)
+        visited_sitemap_urls.add(normalized_url)
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (
+        normalized_url &&
+          visited_sitemap_urls.exclude?(normalized_url)
+      )
+        visited_sitemap_urls.add(normalized_url)
+      end
+    RUBY
+  end
+
+  it 'wraps multiline unless and elsif conditions in parentheses' do
+    expect_offense(<<~RUBY)
+      unless normalized_url &&
+      ^^^^^^ Wrap multiline `unless` conditions in parentheses.
+          visited_sitemap_urls.exclude?(normalized_url)
+        visited_sitemap_urls.add(normalized_url)
+      end
+
+      if ready?
+        visit
+      elsif normalized_url &&
+      ^^^^^ Wrap multiline `elsif` conditions in parentheses.
+          visited_sitemap_urls.exclude?(normalized_url)
+        visited_sitemap_urls.add(normalized_url)
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      unless (
+        normalized_url &&
+          visited_sitemap_urls.exclude?(normalized_url)
+      )
+        visited_sitemap_urls.add(normalized_url)
+      end
+
+      if ready?
+        visit
+      elsif (
+        normalized_url &&
+          visited_sitemap_urls.exclude?(normalized_url)
+      )
+        visited_sitemap_urls.add(normalized_url)
+      end
+    RUBY
+  end
+
+  it 'puts an existing pair of parentheses around a multiline condition on separate lines' do
+    expect_offense(<<~RUBY)
+      if (normalized_url &&
+      ^^ Wrap multiline `if` conditions in parentheses.
+          visited_sitemap_urls.exclude?(normalized_url))
+        visited_sitemap_urls.add(normalized_url)
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (
+        normalized_url &&
+          visited_sitemap_urls.exclude?(normalized_url)
+      )
+        visited_sitemap_urls.add(normalized_url)
+      end
+    RUBY
+  end
+
+  it 'places the closing parenthesis after a trailing condition comment' do
+    expect_offense(<<~RUBY)
+      if normalized_url &&
+      ^^ Wrap multiline `if` conditions in parentheses.
+          visited_sitemap_urls.exclude?(normalized_url) # already normalized
+        visited_sitemap_urls.add(normalized_url)
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      if (
+        normalized_url &&
+          visited_sitemap_urls.exclude?(normalized_url) # already normalized
+      )
+        visited_sitemap_urls.add(normalized_url)
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
Add `RungerStyle/ParenthesesAroundMultilineCondition` to require parenthesized, multiline `if`, `unless`, and `elsif` conditions. Its autocorrection moves the condition below the opening parenthesis, places the closing parenthesis on its own line, and preserves trailing comments.

Allow multiline block conditions and calls on multiline parenthesized receivers because wrapping the entire condition would be redundant or invalid for these forms. The built-in `Style/ParenthesesAroundCondition` does not enforce this multiline layout, so a custom cop is needed. Update the existing keyword-argument condition in `RungerStyle/MultilineMethodArgumentsLineBreaks` so the gem remains clean under its own default ruleset.

codex resume 01a027d3-acb5-78d2-95ac-bbf746b7d6d9