### PR TITLE
Remove 8 methods from Style/MethodCallWithArgsParentheses allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- Remove eight methods from `Style/MethodCallWithArgsParentheses` allowlist.
 
 ## v5.18.0 (2026-08-22)
 - [default] Add `RungerStyle/ParenthesesAroundMultilineCondition` to require parentheses around multiline `if`, `unless`, and `elsif` conditions, except for multiline block conditions and parenthesized receivers.

--- a/rulesets/default.yml
+++ b/rulesets/default.yml
@@ -199,8 +199,6 @@ Style/MethodCallWithArgsParentheses:
     - desc
     - describe
     - drop_table
-    - fail
-    - file
     - float
     - foreign_key
     - gem
@@ -213,9 +211,6 @@ Style/MethodCallWithArgsParentheses:
     - jsonb
     - load
     - not_to
-    - p
-    - print
-    - puts
     - references
     - remove_column
     - remove_index
@@ -223,14 +218,11 @@ Style/MethodCallWithArgsParentheses:
     - require
     - require_relative
     - ruby
-    - run
-    - source
     - string
     - text
     - timestamp
     - timestamps
     - to
-    - visit
 Style/MethodCalledOnDoEndBlock:
   Enabled: false
 Style/MissingElse:


### PR DESCRIPTION
I think I prefer these methods to be called with parentheses.

This mostly leaves Rails schema migration methods, controller responses, and model macros, Ruby code loading methods, and a few DSLs (gemfile, gemspec, RSpec, rakefile).