### PR TITLE
[cops/default] Respect ||= setter calls as macros [STYL-17]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-[no unreleased changes yet]
+- [default] Fix false positives from `RungerStyle/EmptyLineAfterMacro` for `||=` setter calls.
 
 ## v5.19.0 (2026-08-23)
 - Remove eight methods from `Style/MethodCallWithArgsParentheses` allowlist.

--- a/lib/runger_style/cops/default/empty_line_after_macro.rb
+++ b/lib/runger_style/cops/default/empty_line_after_macro.rb
@@ -28,6 +28,8 @@ module RungerStyle # rubocop:disable Style/ClassAndModuleChildren
       method_call = node
       if node.any_block_type?
         method_call = node.send_node
+      elsif node.or_asgn_type?
+        method_call = node.assignment_node
       end
 
       if method_call.send_type? && macro_call?(method_call)

--- a/spec/runger_style/empty_line_after_macro_spec.rb
+++ b/spec/runger_style/empty_line_after_macro_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe RungerStyle::EmptyLineAfterMacro, :config do
       class EmojiPickerController < ApplicationController
         skip_before_action :authenticate_user!
         self.container_classes = %w[p-8]
+        self.use_local_files ||= ::Rails.env.development?
 
         def index
           render :index


### PR DESCRIPTION
`RungerStyle/EmptyLineAfterMacro` already recognizes explicit `self` sends, but Ruby parses `self.foo ||= value` as an `or_asgn` node. Its `assignment_node` holds the `self`-receiver getter, so the existing detector skipped the whole expression and reported a false positive after the preceding macro call.

Unwrap `or_asgn` nodes before applying the existing receiver check. This preserves the distinction between `self`-receiver macros and calls on other receivers while keeping method-body scope protections intact.

codex resume 01a035b2-d153-76e1-bec3-5cfaed94c8e2